### PR TITLE
fix(raft): adjust snapshot and compaction ordering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-raft"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["rmqtt <rmqttd@126.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/raft_node.rs
+++ b/src/raft_node.rs
@@ -1146,12 +1146,12 @@ impl<S: Store + 'static> RaftNode<S> {
                 );
                 let store = self.mut_store();
                 store.set_conf_state(&cs)?;
-                store.compact(last_applied)?;
                 store.create_snapshot(snapshot)?;
+                store.compact(last_applied)?;
             } else {
                 let store = self.mut_store();
                 store.set_conf_state(&cs)?;
-                store.compact(last_applied)?;
+                // store.compact(last_applied)?;
             }
         }
 
@@ -1270,10 +1270,10 @@ impl<S: Store + 'static> RaftNode<S> {
             let last_applied = self.raft.raft_log.applied;
             let snapshot = prost::bytes::Bytes::from(self.store.snapshot().await?);
             let store = self.mut_store();
-            store.compact(last_applied)?;
             let first_index = store.first_index().unwrap_or(0);
             let last_index = store.last_index().unwrap_or(0);
             let result = store.create_snapshot(snapshot);
+            store.compact(last_applied)?;
             info!(
                 "create snapshot cost time: {:?}, first_index: {:?}, last_index: {:?}, {}, create snapshot result: {:?}",
                 self.last_snap_time.elapsed(),


### PR DESCRIPTION
- Bump version from 0.4.6 to 0.4.7
- Reorder snapshot and compaction operations:
  * Create snapshot before compaction during config changes
  * Create snapshot before compaction during periodic snapshots
  * Skip unnecessary compaction after node removal
- Changes ensure:
  * More reliable snapshot creation
  * Avoids potential data loss during compaction
  * Better performance by reducing redundant compactions
- Maintains all existing functionality while fixing edge cases