### PR TITLE
fix(raft): improve node removal handling and snapshot logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-raft"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["rmqtt <rmqttd@126.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- Bump version from 0.5.1 to 0.5.2
- Fix node removal handling:
  * Skip self snapshot when adding own node
  * Use consistent node ID comparisons
  * Improve logging for conf state changes
- Code quality improvements:
  * Replace ctx.len() > 0 with !ctx.is_empty()
  * Remove redundant node ID lookups
  * Clean up conditional logic
- Changes ensure:
  * More reliable cluster membership changes
  * Avoid unnecessary self-snapshots
  * Better debugging logs
- Maintains:
  * Backward compatibility
  * Existing functionality