### PR TITLE
feat(raft): make busy state threshold configurable and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-raft"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["rmqtt <rmqttd@126.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/raft_node.rs
+++ b/src/raft_node.rs
@@ -810,7 +810,8 @@ impl<S: Store + 'static> RaftNode<S> {
 
     #[inline]
     fn is_busy(&self) -> bool {
-        self.sending_raft_messages.load(Ordering::SeqCst) > 500
+        self.sending_raft_messages.load(Ordering::SeqCst)
+            > self.cfg.raft_cfg.max_inflight_msgs as isize
             || self.timeout_recorder.recent_get() > 0
     }
 


### PR DESCRIPTION
- Bump version from 0.5.2 to 0.5.3
- Replace hardcoded busy threshold (500) with configurable max_inflight_msgs
- Maintain existing timeout_recorder check for busy state