### PR TITLE
chore: rebrand vendored raft crates and bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-raft"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["rmqtt <rmqttd@126.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -21,7 +21,7 @@ reuseport = ["socket2", "tokio-stream"]
 reuseaddr = ["socket2", "tokio-stream"]
 
 [dependencies]
-tikv-raft = {package = "raft", path = "./raft-rs", features = [
+tikv-raft = {package = "rmqtt-raft-core", path = "./raft-rs", version = "0.8.0", features = [
     "prost-codec",
 ], default-features = false }
 tokio = { version = "1", default-features = false, features = ["macros"] }

--- a/raft-rs/Cargo.toml
+++ b/raft-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "raft"
-version = "0.7.0"
+name = "rmqtt-raft-core"
+version = "0.8.0"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["raft", "distributed-systems", "ha"]
@@ -31,7 +31,7 @@ fail = { version = "0.4", optional = true }
 getset = "0.1.1"
 protobuf = "3.7.2"
 thiserror = "1.0"
-raft-proto = { path = "proto", version = "0.7.0", default-features = false }
+raft-proto = {package = "rmqtt-raft-proto", path = "./proto", version = "0.8.0", default-features = false }
 rand = "0.8"
 slog = "2.2"
 slog-envlogger = { version = "2.1.0", optional = true }

--- a/raft-rs/proto/Cargo.toml
+++ b/raft-rs/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "raft-proto"
-version = "0.7.0"
+name = "rmqtt-raft-proto"
+version = "0.8.0"
 authors = ["The TiKV Project Developers"]
 edition = "2021"
 license = "Apache-2.0"
@@ -18,7 +18,7 @@ protobuf-codec = ["protobuf-build/protobuf-codec", "bytes", "protobuf/bytes"]
 prost-codec = ["protobuf-build/prost-codec", "prost", "lazy_static"]
 
 [build-dependencies]
-protobuf-build = { path = "./protobuf-build", default-features = false }
+protobuf-build = {package = "rmqtt-protobuf-build", path = "./protobuf-build", version = "0.16.0", default-features = false }
 
 [dependencies]
 bytes = { version = "1", optional = true }

--- a/raft-rs/proto/protobuf-build/Cargo.toml
+++ b/raft-rs/proto/protobuf-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "protobuf-build"
-version = "0.15.1"
+name = "rmqtt-protobuf-build"
+version = "0.16.0"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
- Rename internal raft crates to avoid naming conflicts:
  - `raft` → `rmqtt-raft-core` (version 0.7.0 → 0.8.0)
  - `raft-proto` → `rmqtt-raft-proto` (version 0.7.0 → 0.8.0)
  - `protobuf-build` → `rmqtt-protobuf-build` (version 0.15.1 → 0.16.0)
- Update parent crate rmqtt-raft version from 0.7.0 to 0.7.1
- Update internal dependencies to reference renamed crates with correct versions