### PR TITLE
upgrade vendored raft dependencies and migrate to RMQTT fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Cargo.lock
 /examples/rmqttraft-warp-memstore/.idea/modules.xml
 /examples/rmqttraft-warp-memstore/.idea/rmqttraft-warp-memstore.iml
 /examples/rmqttraft-warp-memstore/.idea/vcs.xml
+/CODEBUDDY.md

--- a/protobuf-v2-to-v3-upgrade-review.md
+++ b/protobuf-v2-to-v3-upgrade-review.md
@@ -1,0 +1,164 @@
+# Protobuf v2 → v3.7.2 升级复核报告
+
+> 复核日期：2026-05-31
+> 复核范围：raft-rs/proto/protobuf-build/compiler/、raft-rs/proto/protobuf-build/、raft-rs/proto/、raft-rs/、./
+> 升级提交：`0b2499a`
+
+---
+
+## 复核结论：没有发现问题 ✅
+
+经过对所有相关目录和文件的完整审查，升级没有引入功能回归或破坏性变更。
+
+---
+
+## 1. 依赖版本变更（Cargo.toml 文件 — 全部正确 ✅）
+
+| 文件 | 行号 | 旧版本 | 新版本 | 状态 |
+|---|---|---|---|---|
+| `protobuf-build/Cargo.toml` | 20-22 | `"2"` | `"3.7.2"` | ✅ |
+| `protobuf-build/compiler/Cargo.toml` | 20 | `"2"` | `"3.7.2"` | ✅ |
+| `protobuf-build/tests/Cargo.toml` | 14 | `"2"` | `"3.7.2"` | ✅ |
+| `raft-rs/proto/Cargo.toml` | 27 | `"2"` | `"3.7.2"` | ✅ |
+| `raft-rs/Cargo.toml` | 32 | `"2"` | `"3.7.2"` | ✅ |
+
+所有依赖统一为 `"3.7.2"`，版本一致性良好。
+
+---
+
+## 2. `protobuf-build/Cargo.toml` — feature 兼容性
+
+```toml
+protobuf-codec = ["protobuf-codegen", "protobuf-parse", "protobuf/with-bytes"]
+```
+
+- `with-bytes` feature 在 protobuf v3.7.2 中仍然存在，用于启用 `bytes::Bytes` 支持 ✅
+- `protobuf-codegen` 和 `protobuf-parse` 在 v3.7.2 中仍然作为独立包提供 ✅
+
+---
+
+## 3. `protobuf-build/src/protobuf_impl.rs` — 代码生成实现
+
+| API 使用 | 行号 | v3.7.2 兼容性 | 状态 |
+|---|---|---|---|
+| `protobuf::Message` trait | 8 | 仍然存在 | ✅ |
+| `protobuf_codegen::CustomizeCallback` | 9 | 在 v3 中有默认 trait 方法实现 | ✅ |
+| `protobuf_parse::ProtoPathBuf::new()` | 61 | 接受 `Into<String>` | ✅ |
+| `FileDescriptorSet::new() + merge_from_bytes()` | 40-41 | v3 API 兼容 | ✅ |
+| `check_initialized()` | 42 | 是 `Message` trait 方法 | ✅ |
+| `gen_and_write::gen_and_write()` | 64-71 | 函数签名与调用匹配 | ✅ |
+| `Customize::default().generate_accessors(true)` | 69 | builder 模式在 v3 中支持 | ✅ |
+| 正则替换 `read_proto3_enum_with_unknown_fields_into` | 82 | 该函数在 `protobuf::rt` 中仍存在 | ✅ |
+
+---
+
+## 4. `protobuf-build/src/wrapper.rs` — Message trait 包装器（关键文件）
+
+这是升级中最关键的改动。wrapper.rs 为 protobuf v3 的 `Message` trait 生成了正确的默认实现：
+
+| 方法 | v2 API | v3.7.2 API | 生成代码是否正确 |
+|---|---|---|---|
+| `const NAME` | ❌ 不存在 | ✅ 必需 | `const NAME: &'static str = "";` ✅ |
+| `compute_size()` | 返回 `u32` | 返回 `u64` | `-> u64` ✅ |
+| `special_fields()` | ❌ 不存在 | ✅ 必需 | `fn special_fields(&self) -> &::protobuf::SpecialFields` ✅ |
+| `mut_special_fields()` | ❌ 不存在 | ✅ 必需 | `fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields` ✅ |
+| 错误类型 | `ProtobufError` | `protobuf::Error` | 使用 `io::Error::new(...).into()` ✅ |
+| `write_to_bytes` | - | - | 正确使用 `prost::Message::encode` + 错误转换 ✅ |
+| `merge_from_bytes` | - | - | 正确使用 `prost::Message::merge` + 错误转换 ✅ |
+
+所有必需的 v3 API 方法都已实现，弃用方法已被移除 ✅
+
+---
+
+## 5. `protobuf-build/compiler/src/codegen.rs` — gRPC 代码生成器
+
+| API | 行号 | v3.7.2 兼容性 | 状态 |
+|---|---|---|---|
+| `protobuf::descriptor::*` | 27 | 模块结构未变 | ✅ |
+| `protobuf::plugin::*` | 28 | `CodeGeneratorRequest` / `CodeGeneratorResponse` 仍存在 | ✅ |
+| `Message::parse_from_reader()` | 46 | 仍然是 Message trait 方法 | ✅ |
+| `CodeGeneratorResponse::new()` | 48 | 仍然存在 | ✅ |
+| `set_supported_features(FEATURE_PROTO3_OPTIONAL as u64)` | 49 | v3 API 中仍兼容 | ✅ |
+| `write_to_writer()` | 59 | Message trait 方法 | ✅ |
+
+`fd.package()`, `fd.message_type`, `fd.service` 等字段访问器仍使用 `protobuf::descriptor` 的 getter API，与 v3 兼容 ✅
+
+---
+
+## 6. `protobuf-build/compiler/src/prost_codegen.rs` — Prost 代码生成器
+
+该文件使用 `prost::Message`（不是 `protobuf::Message`），不依赖于 protobuf v2 API，因此不受升级影响 ✅
+
+---
+
+## 7. `raft-rs/src/errors.rs` — 关键错误类型修复
+
+```
+-    CodecError(#[from] protobuf::ProtobufError),
++    CodecError(#[from] protobuf::Error),
+```
+
+- 在 protobuf v2 中，错误类型是 `protobuf::ProtobufError`
+- 在 protobuf v3.7.2 中，错误类型已重命名为 `protobuf::Error`
+- **这个更改是正确的** ✅
+
+---
+
+## 8. `raft-rs/src/lib.rs` — lint 修复
+
+```
+#![allow(unexpected_cfgs)]
+```
+
+- 这是 Rust 1.80+ 中引入的 lint，用于抑制 prost 生成代码中出现的非预期 cfg 警告 ✅
+- 与 protobuf 升级无直接关联，但不影响功能 ✅
+
+---
+
+## 9. `protobuf-build/src/lib.rs` — protoc 版本检查
+
+```rust
+if (major, minor) >= (3, 1) {
+    return Ok(protoc.to_owned());
+}
+```
+
+- 要求 protoc >= 3.1.0，与 protobuf v3.7.2 兼容 ✅
+- 非 Windows 平台使用 `protobuf-src = "1.1.0"` 获取 protoc 二进制 ✅
+- Windows 使用捆绑的 `protoc-win32.exe` ✅
+
+**小问题（非功能性）**：版本检查正则 `([0-9]+)\.([0-9]+)(\.[0-9])?` 最多只捕获一位 patch 版本号，例如 `3.21.12` 会被识别为 `3.21.1`。但由于只检查 major >= 3, minor >= 1，这不影响实际运行。
+
+---
+
+## 10. 外部 crate 之间的关系
+
+```
+rmqtt-raft (build.rs uses tonic-build 0.9)   ← 不受影响，使用独立的 prost/tonic 生态
+  └─ tikv-raft (= rmqtt-raft-core 0.8.0)
+       └─ raft-proto (= rmqtt-raft-proto 0.8.0)
+            ├─ protobuf = "3.7.2"
+            └─ protobuf-build (= rmqtt-protobuf-build 0.16.0)
+                 ├─ protobuf = "3.7.2"
+                 ├─ protobuf-codegen = "3.7.2"
+                 └─ protobuf-parse = "3.7.2"
+```
+
+依赖链清晰，版本统一为 `3.7.2` ✅
+
+---
+
+## 复核总表
+
+| 检查项 | 结果 |
+|---|---|
+| 所有依赖版本统一为 3.7.2 | ✅ |
+| 错误类型正确迁移（`ProtobufError` → `Error`） | ✅ |
+| `Message` trait impl 方法完整覆盖 v3 API | ✅ |
+| gRPC 代码生成器兼容 v3 descriptor API | ✅ |
+| protoc 版本检查兼容 v3 | ✅ |
+| protobuf 功能 flag（`with-bytes`）兼容 | ✅ |
+| prost 代码路径不受影响 | ✅ |
+| 根 crate（tonic 生态）不受影响 | ✅ |
+
+**升级完全正确，没有遗漏，也没有改变原有功能。** 所有 API 调用都符合 protobuf v3.7.2 的要求，`wrapper.rs` 中的 `Message` trait 实现对 v3 新增的 `special_fields()/mut_special_fields()` 和 `const NAME` 都提供了正确的默认实现。

--- a/raft-rs/Cargo.toml
+++ b/raft-rs/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "rmqtt-raft-core"
 version = "0.8.0"
-authors = ["The TiKV Project Developers"]
+authors = ["The TiKV Project Developers", "rmqtt <rmqttd@126.com>"]
 license = "Apache-2.0"
 keywords = ["raft", "distributed-systems", "ha"]
-repository = "https://github.com/tikv/raft-rs"
+repository = "https://github.com/rmqtt/rmqtt-raft/tree/main/raft-rs"
 readme = "README.md"
-homepage = "https://github.com/tikv/raft-rs"
-documentation = "https://docs.rs/raft"
+homepage = "https://github.com/rmqtt/rmqtt-raft/tree/main/raft-rs"
 description = "The rust language implementation of Raft algorithm."
 categories = ["algorithms", "database-implementations"]
 edition = "2021"

--- a/raft-rs/benches/benches.rs
+++ b/raft-rs/benches/benches.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![allow(dead_code)] // Due to criterion we need this to avoid warnings.
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::let_and_return))] // Benches often artificially return values. Allow it.
+#![cfg_attr(test, allow(clippy::let_and_return))] // Benches often artificially return values. Allow it.
 
 use criterion::Criterion;
 use std::time::Duration;

--- a/raft-rs/benches/suites/progress.rs
+++ b/raft-rs/benches/suites/progress.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use criterion::{Bencher, Criterion};
-use raft::Progress;
+use rmqtt_raft_core::Progress;
 
 pub fn bench_progress(c: &mut Criterion) {
     bench_progress_default(c);

--- a/raft-rs/benches/suites/raft.rs
+++ b/raft-rs/benches/suites/raft.rs
@@ -2,8 +2,8 @@
 
 use crate::DEFAULT_RAFT_SETS;
 use criterion::Criterion;
-use raft::eraftpb::ConfState;
-use raft::{storage::MemStorage, Config, Raft};
+use rmqtt_raft_core::eraftpb::ConfState;
+use rmqtt_raft_core::{storage::MemStorage, Config, Raft};
 
 pub fn bench_raft(c: &mut Criterion) {
     bench_raft_new(c);
@@ -30,7 +30,7 @@ fn quick_raft(storage: MemStorage, logger: &slog::Logger) -> Raft<MemStorage> {
 pub fn bench_raft_new(c: &mut Criterion) {
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
         c.bench_function(&format!("Raft::new ({}, {})", voters, learners), move |b| {
-            let logger = raft::default_logger();
+            let logger = rmqtt_raft_core::default_logger();
             let storage = new_storage(*voters, *learners);
             b.iter(|| quick_raft(storage.clone(), &logger))
         });
@@ -53,7 +53,7 @@ pub fn bench_raft_campaign(c: &mut Criterion) {
                 c.bench_function(
                     &format!("Raft::campaign ({}, {}, {})", voters, learners, msg),
                     move |b| {
-                        let logger = raft::default_logger();
+                        let logger = rmqtt_raft_core::default_logger();
                         let storage = new_storage(*voters, *learners);
                         b.iter(|| {
                             let mut raft = quick_raft(storage.clone(), &logger);

--- a/raft-rs/benches/suites/raw_node.rs
+++ b/raft-rs/benches/suites/raw_node.rs
@@ -5,8 +5,8 @@
 #![allow(clippy::field_reassign_with_default)]
 
 use criterion::{BatchSize, Bencher, BenchmarkId, Criterion, Throughput};
-use raft::eraftpb::{ConfState, Entry, Message, Snapshot, SnapshotMetadata};
-use raft::{storage::MemStorage, Config, RawNode};
+use rmqtt_raft_core::eraftpb::{ConfState, Entry, Message, Snapshot, SnapshotMetadata};
+use rmqtt_raft_core::{storage::MemStorage, Config, RawNode};
 use std::time::Duration;
 
 pub fn bench_raw_node(c: &mut Criterion) {
@@ -25,7 +25,7 @@ fn quick_raw_node(logger: &slog::Logger) -> RawNode<MemStorage> {
 
 pub fn bench_raw_node_new(c: &mut Criterion) {
     let bench = |b: &mut Bencher| {
-        let logger = raft::default_logger();
+        let logger = rmqtt_raft_core::default_logger();
         b.iter(|| quick_raw_node(&logger));
     };
 
@@ -64,7 +64,7 @@ pub fn bench_raw_node_leader_propose(c: &mut Criterion) {
                 BenchmarkId::from_parameter(size),
                 &size,
                 |b: &mut Bencher, size| {
-                    let logger = raft::default_logger();
+                    let logger = rmqtt_raft_core::default_logger();
                     let mut node = quick_raw_node(&logger);
                     node.raft.become_candidate();
                     node.raft.become_leader();
@@ -79,7 +79,7 @@ pub fn bench_raw_node_leader_propose(c: &mut Criterion) {
 }
 
 pub fn bench_raw_node_new_ready(c: &mut Criterion) {
-    let logger = raft::default_logger();
+    let logger = rmqtt_raft_core::default_logger();
     let mut group = c.benchmark_group("RawNode::ready");
     group
         // TODO: The proper measurement time could be affected by the system and machine.

--- a/raft-rs/examples/five_mem_node/main.rs
+++ b/raft-rs/examples/five_mem_node/main.rs
@@ -12,9 +12,9 @@ use std::time::{Duration, Instant};
 use std::{str, thread};
 
 use protobuf::Message as PbMessage;
-use raft::storage::MemStorage;
-use raft::{prelude::*, StateRole};
 use regex::Regex;
+use rmqtt_raft_core::storage::MemStorage;
+use rmqtt_raft_core::{prelude::*, StateRole};
 
 use slog::{error, info, o};
 
@@ -285,7 +285,7 @@ fn on_ready(
                     // From new elected leaders.
                     continue;
                 }
-                if let EntryType::EntryConfChange = entry.get_entry_type() {
+                if let EntryType::EntryConfChange = entry.entry_type() {
                     // For conf change messages, make them effective.
                     let mut cc = ConfChange::default();
                     cc.merge_from_bytes(&entry.data).unwrap();
@@ -355,7 +355,7 @@ fn example_config() -> Config {
 
 // The message can be used to initialize a raft node or not.
 fn is_initial_msg(msg: &Message) -> bool {
-    let msg_type = msg.get_msg_type();
+    let msg_type = msg.msg_type();
     msg_type == MessageType::MsgRequestVote
         || msg_type == MessageType::MsgRequestPreVote
         || (msg_type == MessageType::MsgHeartbeat && msg.commit == 0)

--- a/raft-rs/examples/single_mem_node/main.rs
+++ b/raft-rs/examples/single_mem_node/main.rs
@@ -6,9 +6,9 @@ use std::sync::mpsc::{self, RecvTimeoutError};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use raft::eraftpb::ConfState;
-use raft::prelude::*;
-use raft::storage::MemStorage;
+use rmqtt_raft_core::eraftpb::ConfState;
+use rmqtt_raft_core::prelude::*;
+use rmqtt_raft_core::storage::MemStorage;
 
 use slog::{info, o};
 
@@ -138,7 +138,7 @@ fn on_ready(raft_group: &mut RawNode<MemStorage>, cbs: &mut HashMap<u8, ProposeC
                 continue;
             }
 
-            if entry.get_entry_type() == EntryType::EntryNormal {
+            if entry.entry_type() == EntryType::EntryNormal {
                 if let Some(cb) = cbs.remove(entry.data.first().unwrap()) {
                     cb();
                 }

--- a/raft-rs/harness/Cargo.toml
+++ b/raft-rs/harness/Cargo.toml
@@ -18,8 +18,8 @@ prost-codec = ["raft/prost-codec"]
 
 # Make sure to synchronize updates with Raft.
 [dependencies]
-raft = { path = "..", default-features = false }
-raft-proto = { path = "../proto", default-features = false }
+raft = { package = "rmqtt-raft-core", path = "..", default-features = false }
+raft-proto = {package = "rmqtt-raft-proto", path = "../proto", default-features = false }
 rand = "0.8"
 slog = "2.2"
 

--- a/raft-rs/proto/Cargo.toml
+++ b/raft-rs/proto/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "rmqtt-raft-proto"
 version = "0.8.0"
-authors = ["The TiKV Project Developers"]
+authors = ["The TiKV Project Developers", "rmqtt <rmqttd@126.com>"]
 edition = "2021"
 license = "Apache-2.0"
 keywords = ["raft", "distributed-systems", "ha"]
-repository = "https://github.com/pingcap/raft-rs"
-homepage = "https://github.com/pingcap/raft-rs"
-documentation = "https://docs.rs/raft-proto"
+repository = "https://github.com/rmqtt/rmqtt-raft/tree/main/raft-rs/proto"
+homepage = "https://github.com/rmqtt/rmqtt-raft/tree/main/raft-rs/proto"
 description = "Protocol definitions for the rust language implementation of the Raft algorithm."
 categories = ["algorithms", "database-implementations"]
 build = "build.rs"

--- a/raft-rs/proto/Cargo.toml
+++ b/raft-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@ protobuf-codec = ["protobuf-build/protobuf-codec", "bytes", "protobuf/bytes"]
 prost-codec = ["protobuf-build/prost-codec", "prost", "lazy_static"]
 
 [build-dependencies]
-protobuf-build = {package = "rmqtt-protobuf-build", path = "./protobuf-build", version = "0.16.1", default-features = false }
+protobuf-build = {package = "rmqtt-protobuf-build", path = "./protobuf-build", version = "0.16.2", default-features = false }
 
 [dependencies]
 bytes = { version = "1", optional = true }

--- a/raft-rs/proto/Cargo.toml
+++ b/raft-rs/proto/Cargo.toml
@@ -24,5 +24,4 @@ protobuf-build = {package = "rmqtt-protobuf-build", path = "./protobuf-build", v
 bytes = { version = "1", optional = true }
 lazy_static = { version = "1", optional = true }
 prost = { version = "0.11", optional = true }
-#protobuf = { version = "3.7.2", optional = true }
 protobuf = "3.7.2"

--- a/raft-rs/proto/Cargo.toml
+++ b/raft-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@ protobuf-codec = ["protobuf-build/protobuf-codec", "bytes", "protobuf/bytes"]
 prost-codec = ["protobuf-build/prost-codec", "prost", "lazy_static"]
 
 [build-dependencies]
-protobuf-build = {package = "rmqtt-protobuf-build", path = "./protobuf-build", version = "0.16.0", default-features = false }
+protobuf-build = {package = "rmqtt-protobuf-build", path = "./protobuf-build", version = "0.16.1", default-features = false }
 
 [dependencies]
 bytes = { version = "1", optional = true }

--- a/raft-rs/proto/protobuf-build/Cargo.toml
+++ b/raft-rs/proto/protobuf-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-protobuf-build"
-version = "0.16.1"
+version = "0.16.2"
 authors = ["Nick Cameron <nrc@ncameron.org>", "rmqtt <rmqttd@126.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/raft-rs/proto/protobuf-build/Cargo.toml
+++ b/raft-rs/proto/protobuf-build/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rmqtt-protobuf-build"
-version = "0.16.0"
-authors = ["Nick Cameron <nrc@ncameron.org>"]
+version = "0.16.1"
+authors = ["Nick Cameron <nrc@ncameron.org>", "rmqtt <rmqttd@126.com>"]
 edition = "2018"
 license = "Apache-2.0"
-repository = "https://github.com/tikv/protobuf-build"
-homepage = "https://github.com/tikv/protobuf-build"
+repository = "https://github.com/rmqtt/rmqtt-raft/tree/main/raft-rs/proto/protobuf-build"
+homepage = "https://github.com/rmqtt/rmqtt-raft/tree/main/raft-rs/proto/protobuf-build"
 description = "Utility functions for generating Rust code from protobufs (using protobuf-rust or Prost)"
 
 [features]

--- a/raft-rs/proto/protobuf-build/Cargo.toml
+++ b/raft-rs/proto/protobuf-build/Cargo.toml
@@ -10,7 +10,7 @@ description = "Utility functions for generating Rust code from protobufs (using 
 
 [features]
 default = ["protobuf-codec"]
-protobuf-codec = ["protobuf-codegen", "protobuf/with-bytes"]
+protobuf-codec = ["protobuf-codegen", "protobuf-parse", "protobuf/with-bytes"]
 grpcio-protobuf-codec = ["grpcio-compiler/protobuf-codec", "protobuf-codec"]
 prost-codec = ["syn", "quote", "prost-build", "proc-macro2"]
 grpcio-prost-codec = ["grpcio-compiler/prost-codec", "prost-codec"]
@@ -19,7 +19,8 @@ grpcio-prost-codec = ["grpcio-compiler/prost-codec", "prost-codec"]
 proc-macro2 = { version = "1", optional = true }
 protobuf = { version = "3.7.2", optional = true }
 protobuf-codegen = { version = "3.7.2", optional = true }
-grpcio-compiler = { version = ">=0.8", default-features = false, optional = true }
+protobuf-parse = { version = "3.7.2", optional = true }
+grpcio-compiler = {package = "rmqtt-grpcio-compiler", path = "./compiler", version = "0.14", default-features = false, optional = true }
 prost-build = { version = "0.11", optional = true }
 regex = { version = "1.3" }
 syn = { version = "1.0", features = ["full"], optional = true }
@@ -29,5 +30,3 @@ bitflags = "1.2"
 [target.'cfg(not(windows))'.dependencies]
 protobuf-src = "1.1.0"
 
-[workspace]
-members = ["tests"]

--- a/raft-rs/proto/protobuf-build/compiler/Cargo.toml
+++ b/raft-rs/proto/protobuf-build/compiler/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "rmqtt-grpcio-compiler"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2018"
-authors = ["The TiKV Project Developers"]
+authors = ["The TiKV Project Developers", "rmqtt <rmqttd@126.com>"]
 license = "Apache-2.0"
 keywords = ["compiler", "grpc", "protobuf"]
-repository = "https://github.com/tikv/grpc-rs"
-homepage = "https://github.com/tikv/grpc-rs"
-documentation = "https://docs.rs/grpcio-compiler"
+repository = "https://github.com/rmqtt/rmqtt-raft/tree/main/raft-rs/proto/protobuf-build/compiler"
+homepage = "https://github.com/rmqtt/rmqtt-raft/tree/main/raft-rs/proto/protobuf-build/compiler"
 description = "gRPC compiler for grpcio"
 categories = ["network-programming"]
 

--- a/raft-rs/proto/protobuf-build/compiler/Cargo.toml
+++ b/raft-rs/proto/protobuf-build/compiler/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "rmqtt-grpcio-compiler"
+version = "0.14.0"
+edition = "2018"
+authors = ["The TiKV Project Developers"]
+license = "Apache-2.0"
+keywords = ["compiler", "grpc", "protobuf"]
+repository = "https://github.com/tikv/grpc-rs"
+homepage = "https://github.com/tikv/grpc-rs"
+documentation = "https://docs.rs/grpcio-compiler"
+description = "gRPC compiler for grpcio"
+categories = ["network-programming"]
+
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = ["protobuf"]
+prost-codec = ["prost-build", "prost-types", "prost", "derive-new", "tempfile"]
+
+[dependencies]
+protobuf = { version = "3.7.2", optional = true }
+prost = { version = "0.11", optional = true }
+prost-build = { version = "0.11", optional = true }
+prost-types = { version = "0.11", optional = true }
+derive-new = { version = "0.5", optional = true }
+tempfile = { version = "3.0", optional = true }
+
+[[bin]]
+name = "grpc_rust_plugin"
+required-features = ["protobuf-codec"]
+
+[[bin]]
+name = "grpc_rust_prost"
+required-features = ["prost-codec"]

--- a/raft-rs/proto/protobuf-build/compiler/src/bin/grpc_rust_plugin.rs
+++ b/raft-rs/proto/protobuf-build/compiler/src/bin/grpc_rust_plugin.rs
@@ -1,0 +1,28 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+// Copyright (c) 2016, Stepan Koltsov
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use rmqtt_grpcio_compiler::codegen;
+
+fn main() {
+    codegen::protoc_gen_grpc_rust_main();
+}

--- a/raft-rs/proto/protobuf-build/compiler/src/bin/grpc_rust_prost.rs
+++ b/raft-rs/proto/protobuf-build/compiler/src/bin/grpc_rust_prost.rs
@@ -1,0 +1,7 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use rmqtt_grpcio_compiler::prost_codegen;
+
+fn main() {
+    prost_codegen::protoc_gen_grpc_rust_main();
+}

--- a/raft-rs/proto/protobuf-build/compiler/src/codegen.rs
+++ b/raft-rs/proto/protobuf-build/compiler/src/codegen.rs
@@ -1,0 +1,830 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+// Copyright (c) 2016, Stepan Koltsov
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use std::collections::HashMap;
+use std::io::{stdin, stdout, Write};
+
+use protobuf::descriptor::*;
+use protobuf::plugin::*;
+use protobuf::Message;
+
+use super::util::{self, fq_grpc, to_snake_case, MethodType};
+
+// ---------------------------------------------------------------------------
+// plugin_main - replacement for removed protobuf::compiler_plugin::plugin_main
+// ---------------------------------------------------------------------------
+
+pub struct GenResult {
+    pub name: String,
+    pub content: Vec<u8>,
+}
+
+fn plugin_main<F>(gen: F)
+where
+    F: Fn(&[FileDescriptorProto], &[String]) -> Vec<GenResult>,
+{
+    let req = CodeGeneratorRequest::parse_from_reader(&mut stdin()).unwrap();
+    let result = gen(&req.proto_file, &req.file_to_generate);
+    let mut resp = CodeGeneratorResponse::new();
+    resp.set_supported_features(code_generator_response::Feature::FEATURE_PROTO3_OPTIONAL as u64);
+    resp.file = result
+        .iter()
+        .map(|file| {
+            let mut r = code_generator_response::File::new();
+            r.set_name(file.name.to_string());
+            r.set_content(String::from_utf8(file.content.clone()).unwrap());
+            r
+        })
+        .collect();
+    resp.write_to_writer(&mut stdout()).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// proto_path_to_rust_mod - replacement for removed descriptorx::proto_path_to_rust_mod
+// ---------------------------------------------------------------------------
+
+fn ident_start(c: char) -> bool {
+    c.is_ascii_alphabetic() || c == '_'
+}
+
+fn ident_continue(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+fn proto_path_to_rust_mod(path: &str) -> String {
+    let without_dir = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    let without_suffix = if let Some(pos) = without_dir.rfind(".proto") {
+        &without_dir[..pos]
+    } else {
+        without_dir
+    };
+
+    without_suffix
+        .chars()
+        .enumerate()
+        .map(|(i, c)| {
+            if (i == 0 && ident_start(c)) || ident_continue(c) {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+}
+
+// ---------------------------------------------------------------------------
+// Message resolution - finds message by fully qualified name
+// ---------------------------------------------------------------------------
+
+/// Returns `(file_proto_path, rust_mod_path, rust_type_name)` for a
+/// fully-qualified protobuf message name like `.package.MessageName`.
+///
+/// The `rust_mod_path` is derived from the proto file name, and
+/// `rust_type_name` includes nested prefix parts joined by `_`.
+fn resolve_message<'a>(
+    file_descriptors: &'a [FileDescriptorProto],
+    fqn: &str,
+) -> (&'a FileDescriptorProto, String, String) {
+    assert!(fqn.starts_with('.'), "name must start with dot: {}", fqn);
+    let fqn = &fqn[1..]; // strip leading "."
+
+    for fd in file_descriptors {
+        let package = fd.package();
+        let remaining = if package.is_empty() {
+            fqn
+        } else if let Some(rem) = fqn.strip_prefix(&format!("{}.", package)) {
+            rem
+        } else {
+            continue;
+        };
+
+        // Split the remaining path into message/enum parts and try to resolve.
+        let parts: Vec<&str> = remaining.split('.').collect();
+        if parts.is_empty() {
+            continue;
+        }
+
+        if let Some((path_parts, _)) = find_message_in_file(fd, &parts) {
+            let rust_type_name = path_parts
+                .iter()
+                .map(|m| m.name().to_string())
+                .collect::<Vec<_>>()
+                .join("_");
+
+            let rust_mod = proto_path_to_rust_mod(fd.name());
+
+            return (fd, rust_mod, rust_type_name);
+        }
+    }
+    panic!("message not found by name: .{}", fqn);
+}
+
+/// Recursively search for a message by the dot-separated path parts within a file.
+/// Returns the list of `DescriptorProto` along the path (top-level first), and
+/// the final node.
+fn find_message_in_file<'a>(
+    fd: &'a FileDescriptorProto,
+    parts: &[&str],
+) -> Option<(Vec<&'a DescriptorProto>, &'a DescriptorProto)> {
+    // Try top-level messages first
+    let top = fd.message_type.iter().find(|m| m.name() == parts[0])?;
+
+    let mut path = vec![top];
+    let mut current = top;
+    for part in &parts[1..] {
+        let nested = current.nested_type.iter().find(|m| m.name() == *part)?;
+        path.push(nested);
+        current = nested;
+    }
+    Some((path, current))
+}
+
+// ---------------------------------------------------------------------------
+// CodeWriter
+// ---------------------------------------------------------------------------
+
+struct CodeWriter<'a> {
+    writer: &'a mut (dyn Write + 'a),
+    indent: String,
+}
+
+impl<'a> CodeWriter<'a> {
+    pub fn new(writer: &'a mut dyn Write) -> CodeWriter<'a> {
+        CodeWriter {
+            writer,
+            indent: "".to_string(),
+        }
+    }
+
+    pub fn write_line<S: AsRef<str>>(&mut self, line: S) {
+        (if line.as_ref().is_empty() {
+            self.writer.write_all(b"\n")
+        } else {
+            let s: String = [self.indent.as_ref(), line.as_ref(), "\n"].concat();
+            self.writer.write_all(s.as_bytes())
+        })
+        .unwrap();
+    }
+
+    pub fn write_generated(&mut self) {
+        self.write_line("// This file is generated. Do not edit");
+        self.write_generated_common();
+    }
+
+    fn write_generated_common(&mut self) {
+        // https://secure.phabricator.com/T784
+        self.write_line("// @generated");
+
+        self.write_line("");
+        self.comment("https://github.com/Manishearth/rust-clippy/issues/702");
+        self.write_line("#![allow(unknown_lints)]");
+        self.write_line("#![allow(clippy::all)]");
+        self.write_line("");
+        self.write_line("#![allow(box_pointers)]");
+        self.write_line("#![allow(dead_code)]");
+        self.write_line("#![allow(missing_docs)]");
+        self.write_line("#![allow(non_camel_case_types)]");
+        self.write_line("#![allow(non_snake_case)]");
+        self.write_line("#![allow(non_upper_case_globals)]");
+        self.write_line("#![allow(trivial_casts)]");
+        self.write_line("#![allow(unsafe_code)]");
+        self.write_line("#![allow(unused_imports)]");
+        self.write_line("#![allow(unused_results)]");
+    }
+
+    pub fn indented<F>(&mut self, cb: F)
+    where
+        F: Fn(&mut CodeWriter),
+    {
+        cb(&mut CodeWriter {
+            writer: self.writer,
+            indent: format!("{}    ", self.indent),
+        });
+    }
+
+    #[allow(dead_code)]
+    pub fn commented<F>(&mut self, cb: F)
+    where
+        F: Fn(&mut CodeWriter),
+    {
+        cb(&mut CodeWriter {
+            writer: self.writer,
+            indent: format!("// {}", self.indent),
+        });
+    }
+
+    pub fn block<F>(&mut self, first_line: &str, last_line: &str, cb: F)
+    where
+        F: Fn(&mut CodeWriter),
+    {
+        self.write_line(first_line);
+        self.indented(cb);
+        self.write_line(last_line);
+    }
+
+    pub fn expr_block<F>(&mut self, prefix: &str, cb: F)
+    where
+        F: Fn(&mut CodeWriter),
+    {
+        self.block(&format!("{prefix} {{"), "}", cb);
+    }
+
+    pub fn impl_self_block<S: AsRef<str>, F>(&mut self, name: S, cb: F)
+    where
+        F: Fn(&mut CodeWriter),
+    {
+        self.expr_block(&format!("impl {}", name.as_ref()), cb);
+    }
+
+    pub fn pub_struct<S: AsRef<str>, F>(&mut self, name: S, cb: F)
+    where
+        F: Fn(&mut CodeWriter),
+    {
+        self.expr_block(&format!("pub struct {}", name.as_ref()), cb);
+    }
+
+    pub fn pub_trait<F>(&mut self, name: &str, cb: F)
+    where
+        F: Fn(&mut CodeWriter),
+    {
+        self.expr_block(&format!("pub trait {name}"), cb);
+    }
+
+    pub fn field_entry(&mut self, name: &str, value: &str) {
+        self.write_line(format!("{name}: {value},"));
+    }
+
+    pub fn field_decl(&mut self, name: &str, field_type: &str) {
+        self.write_line(format!("{name}: {field_type},"));
+    }
+
+    pub fn comment(&mut self, comment: &str) {
+        if comment.is_empty() {
+            self.write_line("//");
+        } else {
+            self.write_line(format!("// {comment}"));
+        }
+    }
+
+    pub fn fn_block<F>(&mut self, public: bool, sig: &str, cb: F)
+    where
+        F: Fn(&mut CodeWriter),
+    {
+        if public {
+            self.expr_block(&format!("pub fn {sig}"), cb);
+        } else {
+            self.expr_block(&format!("fn {sig}"), cb);
+        }
+    }
+
+    pub fn pub_fn<F>(&mut self, sig: &str, cb: F)
+    where
+        F: Fn(&mut CodeWriter),
+    {
+        self.fn_block(true, sig, cb);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MethodGen / ServiceGen
+// ---------------------------------------------------------------------------
+
+struct MethodGen<'a> {
+    proto: &'a MethodDescriptorProto,
+    service_name: String,
+    service_path: String,
+    file_descriptors: &'a [FileDescriptorProto],
+}
+
+impl<'a> MethodGen<'a> {
+    fn new(
+        proto: &'a MethodDescriptorProto,
+        service_name: String,
+        service_path: String,
+        file_descriptors: &'a [FileDescriptorProto],
+    ) -> MethodGen<'a> {
+        MethodGen {
+            proto,
+            service_name,
+            service_path,
+            file_descriptors,
+        }
+    }
+
+    fn input(&self) -> String {
+        let (_, rust_mod, rust_type_name) =
+            resolve_message(self.file_descriptors, self.proto.input_type());
+        format!("super::{}::{}", rust_mod, rust_type_name)
+    }
+
+    fn output(&self) -> String {
+        let (_, rust_mod, rust_type_name) =
+            resolve_message(self.file_descriptors, self.proto.output_type());
+        format!("super::{}::{}", rust_mod, rust_type_name)
+    }
+
+    fn method_type(&self) -> (MethodType, String) {
+        match (self.proto.client_streaming(), self.proto.server_streaming()) {
+            (false, false) => (MethodType::Unary, fq_grpc("MethodType::Unary")),
+            (true, false) => (
+                MethodType::ClientStreaming,
+                fq_grpc("MethodType::ClientStreaming"),
+            ),
+            (false, true) => (
+                MethodType::ServerStreaming,
+                fq_grpc("MethodType::ServerStreaming"),
+            ),
+            (true, true) => (MethodType::Duplex, fq_grpc("MethodType::Duplex")),
+        }
+    }
+
+    fn service_name(&self) -> String {
+        to_snake_case(&self.service_name)
+    }
+
+    fn name(&self) -> String {
+        to_snake_case(self.proto.name())
+    }
+
+    fn fq_name(&self) -> String {
+        format!("\"{}/{}\"", self.service_path, self.proto.name())
+    }
+
+    fn const_method_name(&self) -> String {
+        format!(
+            "METHOD_{}_{}",
+            self.service_name().to_uppercase(),
+            self.name().to_uppercase()
+        )
+    }
+
+    fn write_definition(&self, w: &mut CodeWriter) {
+        let head = format!(
+            "const {}: {}<{}, {}> = {} {{",
+            self.const_method_name(),
+            fq_grpc("Method"),
+            self.input(),
+            self.output(),
+            fq_grpc("Method")
+        );
+        let pb_mar = format!(
+            "{} {{ ser: {}, de: {} }}",
+            fq_grpc("Marshaller"),
+            fq_grpc("pb_ser"),
+            fq_grpc("pb_de")
+        );
+        w.block(&head, "};", |w| {
+            w.field_entry("ty", &self.method_type().1);
+            w.field_entry("name", &self.fq_name());
+            w.field_entry("req_mar", &pb_mar);
+            w.field_entry("resp_mar", &pb_mar);
+        });
+    }
+
+    // Method signatures
+    fn unary(&self, method_name: &str) -> String {
+        format!(
+            "{}(&self, req: &{}) -> {}<{}>",
+            method_name,
+            self.input(),
+            fq_grpc("Result"),
+            self.output()
+        )
+    }
+
+    fn unary_opt(&self, method_name: &str) -> String {
+        format!(
+            "{}_opt(&self, req: &{}, opt: {}) -> {}<{}>",
+            method_name,
+            self.input(),
+            fq_grpc("CallOption"),
+            fq_grpc("Result"),
+            self.output()
+        )
+    }
+
+    fn unary_async(&self, method_name: &str) -> String {
+        format!(
+            "{}_async(&self, req: &{}) -> {}<{}<{}>>",
+            method_name,
+            self.input(),
+            fq_grpc("Result"),
+            fq_grpc("ClientUnaryReceiver"),
+            self.output()
+        )
+    }
+
+    fn unary_async_opt(&self, method_name: &str) -> String {
+        format!(
+            "{}_async_opt(&self, req: &{}, opt: {}) -> {}<{}<{}>>",
+            method_name,
+            self.input(),
+            fq_grpc("CallOption"),
+            fq_grpc("Result"),
+            fq_grpc("ClientUnaryReceiver"),
+            self.output()
+        )
+    }
+
+    fn client_streaming(&self, method_name: &str) -> String {
+        format!(
+            "{}(&self) -> {}<({}<{}>, {}<{}>)>",
+            method_name,
+            fq_grpc("Result"),
+            fq_grpc("ClientCStreamSender"),
+            self.input(),
+            fq_grpc("ClientCStreamReceiver"),
+            self.output()
+        )
+    }
+
+    fn client_streaming_opt(&self, method_name: &str) -> String {
+        format!(
+            "{}_opt(&self, opt: {}) -> {}<({}<{}>, {}<{}>)>",
+            method_name,
+            fq_grpc("CallOption"),
+            fq_grpc("Result"),
+            fq_grpc("ClientCStreamSender"),
+            self.input(),
+            fq_grpc("ClientCStreamReceiver"),
+            self.output()
+        )
+    }
+
+    fn server_streaming(&self, method_name: &str) -> String {
+        format!(
+            "{}(&self, req: &{}) -> {}<{}<{}>>",
+            method_name,
+            self.input(),
+            fq_grpc("Result"),
+            fq_grpc("ClientSStreamReceiver"),
+            self.output()
+        )
+    }
+
+    fn server_streaming_opt(&self, method_name: &str) -> String {
+        format!(
+            "{}_opt(&self, req: &{}, opt: {}) -> {}<{}<{}>>",
+            method_name,
+            self.input(),
+            fq_grpc("CallOption"),
+            fq_grpc("Result"),
+            fq_grpc("ClientSStreamReceiver"),
+            self.output()
+        )
+    }
+
+    fn duplex_streaming(&self, method_name: &str) -> String {
+        format!(
+            "{}(&self) -> {}<({}<{}>, {}<{}>)>",
+            method_name,
+            fq_grpc("Result"),
+            fq_grpc("ClientDuplexSender"),
+            self.input(),
+            fq_grpc("ClientDuplexReceiver"),
+            self.output()
+        )
+    }
+
+    fn duplex_streaming_opt(&self, method_name: &str) -> String {
+        format!(
+            "{}_opt(&self, opt: {}) -> {}<({}<{}>, {}<{}>)>",
+            method_name,
+            fq_grpc("CallOption"),
+            fq_grpc("Result"),
+            fq_grpc("ClientDuplexSender"),
+            self.input(),
+            fq_grpc("ClientDuplexReceiver"),
+            self.output()
+        )
+    }
+
+    fn write_client(&self, w: &mut CodeWriter) {
+        let method_name = self.name();
+        match self.method_type().0 {
+            // Unary
+            MethodType::Unary => {
+                w.pub_fn(&self.unary_opt(&method_name), |w| {
+                    w.write_line(format!(
+                        "self.client.unary_call(&{}, req, opt)",
+                        self.const_method_name()
+                    ));
+                });
+                w.write_line("");
+
+                w.pub_fn(&self.unary(&method_name), |w| {
+                    w.write_line(format!(
+                        "self.{}_opt(req, {})",
+                        method_name,
+                        fq_grpc("CallOption::default()")
+                    ));
+                });
+                w.write_line("");
+
+                w.pub_fn(&self.unary_async_opt(&method_name), |w| {
+                    w.write_line(format!(
+                        "self.client.unary_call_async(&{}, req, opt)",
+                        self.const_method_name()
+                    ));
+                });
+                w.write_line("");
+
+                w.pub_fn(&self.unary_async(&method_name), |w| {
+                    w.write_line(format!(
+                        "self.{}_async_opt(req, {})",
+                        method_name,
+                        fq_grpc("CallOption::default()")
+                    ));
+                });
+            }
+
+            // Client streaming
+            MethodType::ClientStreaming => {
+                w.pub_fn(&self.client_streaming_opt(&method_name), |w| {
+                    w.write_line(format!(
+                        "self.client.client_streaming(&{}, opt)",
+                        self.const_method_name()
+                    ));
+                });
+                w.write_line("");
+
+                w.pub_fn(&self.client_streaming(&method_name), |w| {
+                    w.write_line(format!(
+                        "self.{}_opt({})",
+                        method_name,
+                        fq_grpc("CallOption::default()")
+                    ));
+                });
+            }
+
+            // Server streaming
+            MethodType::ServerStreaming => {
+                w.pub_fn(&self.server_streaming_opt(&method_name), |w| {
+                    w.write_line(format!(
+                        "self.client.server_streaming(&{}, req, opt)",
+                        self.const_method_name()
+                    ));
+                });
+                w.write_line("");
+
+                w.pub_fn(&self.server_streaming(&method_name), |w| {
+                    w.write_line(format!(
+                        "self.{}_opt(req, {})",
+                        method_name,
+                        fq_grpc("CallOption::default()")
+                    ));
+                });
+            }
+
+            // Duplex streaming
+            MethodType::Duplex => {
+                w.pub_fn(&self.duplex_streaming_opt(&method_name), |w| {
+                    w.write_line(format!(
+                        "self.client.duplex_streaming(&{}, opt)",
+                        self.const_method_name()
+                    ));
+                });
+                w.write_line("");
+
+                w.pub_fn(&self.duplex_streaming(&method_name), |w| {
+                    w.write_line(format!(
+                        "self.{}_opt({})",
+                        method_name,
+                        fq_grpc("CallOption::default()")
+                    ));
+                });
+            }
+        };
+    }
+
+    fn write_service(&self, w: &mut CodeWriter) {
+        let req_stream_type = format!("{}<{}>", fq_grpc("RequestStream"), self.input());
+        let (req, req_type, resp_type) = match self.method_type().0 {
+            MethodType::Unary => ("req", self.input(), "UnarySink"),
+            MethodType::ClientStreaming => ("stream", req_stream_type, "ClientStreamingSink"),
+            MethodType::ServerStreaming => ("req", self.input(), "ServerStreamingSink"),
+            MethodType::Duplex => ("stream", req_stream_type, "DuplexSink"),
+        };
+        let sig = format!(
+            "{}(&mut self, ctx: {}, _{}: {}, sink: {}<{}>)",
+            self.name(),
+            fq_grpc("RpcContext"),
+            req,
+            req_type,
+            fq_grpc(resp_type),
+            self.output()
+        );
+        w.fn_block(false, &sig, |w| {
+            w.write_line("grpcio::unimplemented_call!(ctx, sink)");
+        });
+    }
+
+    fn write_bind(&self, w: &mut CodeWriter) {
+        let add = match self.method_type().0 {
+            MethodType::Unary => "add_unary_handler",
+            MethodType::ClientStreaming => "add_client_streaming_handler",
+            MethodType::ServerStreaming => "add_server_streaming_handler",
+            MethodType::Duplex => "add_duplex_streaming_handler",
+        };
+        w.block(
+            &format!(
+                "builder = builder.{}(&{}, move |ctx, req, resp| {{",
+                add,
+                self.const_method_name()
+            ),
+            "});",
+            |w| {
+                w.write_line(format!("instance.{}(ctx, req, resp)", self.name()));
+            },
+        );
+    }
+}
+
+struct ServiceGen<'a> {
+    proto: &'a ServiceDescriptorProto,
+    methods: Vec<MethodGen<'a>>,
+}
+
+impl<'a> ServiceGen<'a> {
+    fn new(
+        proto: &'a ServiceDescriptorProto,
+        file: &FileDescriptorProto,
+        file_descriptors: &'a [FileDescriptorProto],
+    ) -> ServiceGen<'a> {
+        let service_path = if file.package().is_empty() {
+            format!("/{}", proto.name())
+        } else {
+            format!("/{}.{}", file.package(), proto.name())
+        };
+        let methods = proto
+            .method
+            .iter()
+            .map(|m| {
+                MethodGen::new(
+                    m,
+                    util::to_camel_case(proto.name()),
+                    service_path.clone(),
+                    file_descriptors,
+                )
+            })
+            .collect();
+
+        ServiceGen { proto, methods }
+    }
+
+    fn service_name(&self) -> String {
+        util::to_camel_case(self.proto.name())
+    }
+
+    fn client_name(&self) -> String {
+        format!("{}Client", self.service_name())
+    }
+
+    fn write_client(&self, w: &mut CodeWriter) {
+        w.write_line("#[derive(Clone)]");
+        w.pub_struct(self.client_name(), |w| {
+            w.field_decl("pub client", "::grpcio::Client");
+        });
+
+        w.write_line("");
+
+        w.impl_self_block(self.client_name(), |w| {
+            w.pub_fn("new(channel: ::grpcio::Channel) -> Self", |w| {
+                w.expr_block(&self.client_name(), |w| {
+                    w.field_entry("client", "::grpcio::Client::new(channel)");
+                });
+            });
+
+            for method in &self.methods {
+                w.write_line("");
+                method.write_client(w);
+            }
+            w.pub_fn(
+                "spawn<F>(&self, f: F) where F: ::std::future::Future<Output = ()> + Send + 'static",
+                |w| {
+                    w.write_line("self.client.spawn(f)");
+                },
+            )
+        });
+    }
+
+    fn write_server(&self, w: &mut CodeWriter) {
+        w.pub_trait(&self.service_name(), |w| {
+            for method in &self.methods {
+                method.write_service(w);
+            }
+        });
+
+        w.write_line("");
+
+        let s = format!(
+            "create_{}<S: {} + Send + Clone + 'static>(s: S) -> {}",
+            to_snake_case(&self.service_name()),
+            self.service_name(),
+            fq_grpc("Service")
+        );
+        w.pub_fn(&s, |w| {
+            w.write_line("let mut builder = ::grpcio::ServiceBuilder::new();");
+            for method in &self.methods[0..self.methods.len() - 1] {
+                w.write_line("let mut instance = s.clone();");
+                method.write_bind(w);
+            }
+
+            w.write_line("let mut instance = s;");
+            self.methods[self.methods.len() - 1].write_bind(w);
+
+            w.write_line("builder.build()");
+        });
+    }
+
+    fn write_method_definitions(&self, w: &mut CodeWriter) {
+        for (i, method) in self.methods.iter().enumerate() {
+            if i != 0 {
+                w.write_line("");
+            }
+
+            method.write_definition(w);
+        }
+    }
+
+    fn write(&self, w: &mut CodeWriter) {
+        self.write_method_definitions(w);
+        w.write_line("");
+        self.write_client(w);
+        w.write_line("");
+        self.write_server(w);
+    }
+}
+
+fn gen_file(
+    file: &FileDescriptorProto,
+    file_descriptors: &[FileDescriptorProto],
+) -> Option<GenResult> {
+    if file.service.is_empty() {
+        return None;
+    }
+
+    let base = proto_path_to_rust_mod(file.name());
+
+    let mut v = Vec::new();
+    {
+        let mut w = CodeWriter::new(&mut v);
+        w.write_generated();
+
+        for service in &file.service {
+            w.write_line("");
+            ServiceGen::new(service, file, file_descriptors).write(&mut w);
+        }
+    }
+
+    Some(GenResult {
+        name: base + "_grpc.rs",
+        content: v,
+    })
+}
+
+pub fn gen(
+    file_descriptors: &[FileDescriptorProto],
+    files_to_generate: &[String],
+) -> Vec<GenResult> {
+    let files_map: HashMap<&str, &FileDescriptorProto> =
+        file_descriptors.iter().map(|f| (f.name(), f)).collect();
+
+    let mut results = Vec::new();
+
+    for file_name in files_to_generate {
+        let file = files_map[&file_name[..]];
+
+        if file.service.is_empty() {
+            continue;
+        }
+
+        results.extend(gen_file(file, file_descriptors).into_iter());
+    }
+
+    results
+}
+
+pub fn protoc_gen_grpc_rust_main() {
+    plugin_main(gen);
+}

--- a/raft-rs/proto/protobuf-build/compiler/src/lib.rs
+++ b/raft-rs/proto/protobuf-build/compiler/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+#[cfg(feature = "protobuf-codec")]
+pub mod codegen;
+#[cfg(feature = "prost-codec")]
+pub mod prost_codegen;
+
+mod util;

--- a/raft-rs/proto/protobuf-build/compiler/src/prost_codegen.rs
+++ b/raft-rs/proto/protobuf-build/compiler/src/prost_codegen.rs
@@ -1,0 +1,579 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::io::{Error, Read};
+use std::path::Path;
+use std::{env, fs, io, process::Command, str};
+
+use derive_new::new;
+use prost::Message;
+use prost_build::{Config, Method, Service, ServiceGenerator};
+use prost_types::FileDescriptorSet;
+
+use crate::util::{fq_grpc, to_snake_case, MethodType};
+
+/// Returns the names of all packages compiled.
+pub fn compile_protos<P>(protos: &[P], includes: &[P], out_dir: &str) -> io::Result<Vec<String>>
+where
+    P: AsRef<Path>,
+{
+    let mut prost_config = Config::new();
+    prost_config.service_generator(Box::new(Generator));
+    prost_config.out_dir(out_dir);
+
+    // Create a file descriptor set for the protocol files.
+    let tmp = tempfile::Builder::new().prefix("prost-build").tempdir()?;
+    std::fs::create_dir_all(tmp.path())?;
+    let descriptor_set = tmp.path().join("prost-descriptor-set");
+
+    let mut cmd = Command::new(prost_build::protoc_from_env());
+    cmd.arg("--include_imports")
+        .arg("--include_source_info")
+        .arg("-o")
+        .arg(&descriptor_set);
+
+    for include in includes {
+        cmd.arg("-I").arg(include.as_ref());
+    }
+
+    // Set the protoc include after the user includes in case the user wants to
+    // override one of the built-in .protos.
+    if let Some(inc) = prost_build::protoc_include_from_env() {
+        cmd.arg("-I").arg(inc);
+    }
+
+    for proto in protos {
+        cmd.arg(proto.as_ref());
+    }
+
+    let output = cmd.output()?;
+    if !output.status.success() {
+        return Err(Error::other(format!(
+            "protoc failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    let mut buf = Vec::new();
+    fs::File::open(descriptor_set)?.read_to_end(&mut buf)?;
+    let descriptor_set = FileDescriptorSet::decode(buf.as_slice())?;
+
+    // Get the package names from the descriptor set.
+    let mut packages: Vec<_> = descriptor_set
+        .file
+        .iter()
+        .filter_map(|f| f.package.clone())
+        .collect();
+    packages.sort();
+    packages.dedup();
+
+    // FIXME(https://github.com/danburkert/prost/pull/155)
+    // Unfortunately we have to forget the above work and use `compile_protos` to
+    // actually generate the Rust code.
+    prost_config.compile_protos(protos, includes)?;
+
+    Ok(packages)
+}
+
+/// [`ServiceGenerator`](prost_build::ServiceGenerator) for generating grpcio services.
+///
+/// Can be used for when there is a need to deviate from the common use case of
+/// [`compile_protos()`]. One can provide a `Generator` instance to
+/// [`prost_build::Config::service_generator()`].
+///
+/// ```rust,no_run
+/// use prost_build::Config;
+/// use rmqtt_grpcio_compiler::prost_codegen::Generator;
+///
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let mut config = Config::new();
+///     config.service_generator(Box::new(Generator));
+///     // Modify config as needed
+///     config.compile_protos(&["src/frontend.proto", "src/backend.proto"], &["src"])?;
+///     Ok(())
+/// }
+/// ```
+pub struct Generator;
+
+impl ServiceGenerator for Generator {
+    fn generate(&mut self, service: Service, buf: &mut String) {
+        generate_methods(&service, buf);
+        generate_client(&service, buf);
+        generate_server(&service, buf);
+    }
+}
+
+fn generate_methods(service: &Service, buf: &mut String) {
+    let service_path = if service.package.is_empty() {
+        format!("/{}", service.proto_name)
+    } else {
+        format!("/{}.{}", service.package, service.proto_name)
+    };
+
+    for method in &service.methods {
+        generate_method(&service.name, &service_path, method, buf);
+    }
+}
+
+fn const_method_name(service_name: &str, method: &Method) -> String {
+    format!(
+        "METHOD_{}_{}",
+        to_snake_case(service_name).to_uppercase(),
+        method.name.to_uppercase()
+    )
+}
+
+fn generate_method(service_name: &str, service_path: &str, method: &Method, buf: &mut String) {
+    let name = const_method_name(service_name, method);
+    let ty = format!(
+        "{}<{}, {}>",
+        fq_grpc("Method"),
+        method.input_type,
+        method.output_type
+    );
+
+    buf.push_str("const ");
+    buf.push_str(&name);
+    buf.push_str(": ");
+    buf.push_str(&ty);
+    buf.push_str(" = ");
+    generate_method_body(service_path, method, buf);
+}
+
+fn generate_method_body(service_path: &str, method: &Method, buf: &mut String) {
+    let ty = fq_grpc(&MethodType::from_method(method).to_string());
+    let pr_mar = format!(
+        "{} {{ ser: {}, de: {} }}",
+        fq_grpc("Marshaller"),
+        fq_grpc("pr_ser"),
+        fq_grpc("pr_de")
+    );
+
+    buf.push_str(&fq_grpc("Method"));
+    buf.push('{');
+    generate_field_init("ty", &ty, buf);
+    generate_field_init(
+        "name",
+        &format!("\"{}/{}\"", service_path, method.proto_name),
+        buf,
+    );
+    generate_field_init("req_mar", &pr_mar, buf);
+    generate_field_init("resp_mar", &pr_mar, buf);
+    buf.push_str("};\n");
+}
+
+// TODO share this code with protobuf codegen
+impl MethodType {
+    fn from_method(method: &Method) -> MethodType {
+        match (method.client_streaming, method.server_streaming) {
+            (false, false) => MethodType::Unary,
+            (true, false) => MethodType::ClientStreaming,
+            (false, true) => MethodType::ServerStreaming,
+            (true, true) => MethodType::Duplex,
+        }
+    }
+}
+
+fn generate_field_init(name: &str, value: &str, buf: &mut String) {
+    buf.push_str(name);
+    buf.push_str(": ");
+    buf.push_str(value);
+    buf.push_str(", ");
+}
+
+fn generate_client(service: &Service, buf: &mut String) {
+    let client_name = format!("{}Client", service.name);
+    buf.push_str("#[derive(Clone)]\n");
+    buf.push_str("pub struct ");
+    buf.push_str(&client_name);
+    buf.push_str(" { pub client: ::grpcio::Client }\n");
+
+    buf.push_str("impl ");
+    buf.push_str(&client_name);
+    buf.push_str(" {\n");
+    generate_ctor(&client_name, buf);
+    generate_client_methods(service, buf);
+    generate_spawn(buf);
+    buf.push_str("}\n")
+}
+
+fn generate_ctor(client_name: &str, buf: &mut String) {
+    buf.push_str("pub fn new(channel: ::grpcio::Channel) -> Self { ");
+    buf.push_str(client_name);
+    buf.push_str(" { client: ::grpcio::Client::new(channel) }");
+    buf.push_str("}\n");
+}
+
+fn generate_client_methods(service: &Service, buf: &mut String) {
+    for method in &service.methods {
+        generate_client_method(&service.name, method, buf);
+    }
+}
+
+fn generate_client_method(service_name: &str, method: &Method, buf: &mut String) {
+    let name = &format!(
+        "METHOD_{}_{}",
+        to_snake_case(service_name).to_uppercase(),
+        method.name.to_uppercase()
+    );
+    match MethodType::from_method(method) {
+        MethodType::Unary => {
+            ClientMethod::new(
+                &method.name,
+                true,
+                Some(&method.input_type),
+                false,
+                vec![&method.output_type],
+                "unary_call",
+                name,
+            )
+            .generate(buf);
+            ClientMethod::new(
+                &method.name,
+                false,
+                Some(&method.input_type),
+                false,
+                vec![&method.output_type],
+                "unary_call",
+                name,
+            )
+            .generate(buf);
+            ClientMethod::new(
+                &method.name,
+                true,
+                Some(&method.input_type),
+                true,
+                vec![&format!(
+                    "{}<{}>",
+                    fq_grpc("ClientUnaryReceiver"),
+                    method.output_type
+                )],
+                "unary_call",
+                name,
+            )
+            .generate(buf);
+            ClientMethod::new(
+                &method.name,
+                false,
+                Some(&method.input_type),
+                true,
+                vec![&format!(
+                    "{}<{}>",
+                    fq_grpc("ClientUnaryReceiver"),
+                    method.output_type
+                )],
+                "unary_call",
+                name,
+            )
+            .generate(buf);
+        }
+        MethodType::ClientStreaming => {
+            ClientMethod::new(
+                &method.name,
+                true,
+                None,
+                false,
+                vec![
+                    &format!("{}<{}>", fq_grpc("ClientCStreamSender"), method.input_type),
+                    &format!(
+                        "{}<{}>",
+                        fq_grpc("ClientCStreamReceiver"),
+                        method.output_type
+                    ),
+                ],
+                "client_streaming",
+                name,
+            )
+            .generate(buf);
+            ClientMethod::new(
+                &method.name,
+                false,
+                None,
+                false,
+                vec![
+                    &format!("{}<{}>", fq_grpc("ClientCStreamSender"), method.input_type),
+                    &format!(
+                        "{}<{}>",
+                        fq_grpc("ClientCStreamReceiver"),
+                        method.output_type
+                    ),
+                ],
+                "client_streaming",
+                name,
+            )
+            .generate(buf);
+        }
+        MethodType::ServerStreaming => {
+            ClientMethod::new(
+                &method.name,
+                true,
+                Some(&method.input_type),
+                false,
+                vec![&format!(
+                    "{}<{}>",
+                    fq_grpc("ClientSStreamReceiver"),
+                    method.output_type
+                )],
+                "server_streaming",
+                name,
+            )
+            .generate(buf);
+            ClientMethod::new(
+                &method.name,
+                false,
+                Some(&method.input_type),
+                false,
+                vec![&format!(
+                    "{}<{}>",
+                    fq_grpc("ClientSStreamReceiver"),
+                    method.output_type
+                )],
+                "server_streaming",
+                name,
+            )
+            .generate(buf);
+        }
+        MethodType::Duplex => {
+            ClientMethod::new(
+                &method.name,
+                true,
+                None,
+                false,
+                vec![
+                    &format!("{}<{}>", fq_grpc("ClientDuplexSender"), method.input_type),
+                    &format!(
+                        "{}<{}>",
+                        fq_grpc("ClientDuplexReceiver"),
+                        method.output_type
+                    ),
+                ],
+                "duplex_streaming",
+                name,
+            )
+            .generate(buf);
+            ClientMethod::new(
+                &method.name,
+                false,
+                None,
+                false,
+                vec![
+                    &format!("{}<{}>", fq_grpc("ClientDuplexSender"), method.input_type),
+                    &format!(
+                        "{}<{}>",
+                        fq_grpc("ClientDuplexReceiver"),
+                        method.output_type
+                    ),
+                ],
+                "duplex_streaming",
+                name,
+            )
+            .generate(buf);
+        }
+    }
+}
+
+#[derive(new)]
+struct ClientMethod<'a> {
+    method_name: &'a str,
+    opt: bool,
+    request: Option<&'a str>,
+    r#async: bool,
+    result_types: Vec<&'a str>,
+    inner_method_name: &'a str,
+    data_name: &'a str,
+}
+
+impl<'a> ClientMethod<'a> {
+    fn generate(&self, buf: &mut String) {
+        buf.push_str("pub fn ");
+
+        buf.push_str(self.method_name);
+        if self.r#async {
+            buf.push_str("_async");
+        }
+        if self.opt {
+            buf.push_str("_opt");
+        }
+
+        buf.push_str("(&self");
+        if let Some(req) = self.request {
+            buf.push_str(", req: &");
+            buf.push_str(req);
+        }
+        if self.opt {
+            buf.push_str(", opt: ");
+            buf.push_str(&fq_grpc("CallOption"));
+        }
+        buf.push_str(") -> ");
+
+        buf.push_str(&fq_grpc("Result"));
+        buf.push('<');
+        if self.result_types.len() != 1 {
+            buf.push('(');
+        }
+        for rt in &self.result_types {
+            buf.push_str(rt);
+            buf.push(',');
+        }
+        if self.result_types.len() != 1 {
+            buf.push(')');
+        }
+        buf.push_str("> { ");
+        if self.opt {
+            self.generate_inner_body(buf);
+        } else {
+            self.generate_opt_body(buf);
+        }
+        buf.push_str(" }\n");
+    }
+
+    // Method delegates to the `_opt` version of the method.
+    fn generate_opt_body(&self, buf: &mut String) {
+        buf.push_str("self.");
+        buf.push_str(self.method_name);
+        if self.r#async {
+            buf.push_str("_async");
+        }
+        buf.push_str("_opt(");
+        if self.request.is_some() {
+            buf.push_str("req, ");
+        }
+        buf.push_str(&fq_grpc("CallOption::default()"));
+        buf.push(')');
+    }
+
+    // Method delegates to the inner client.
+    fn generate_inner_body(&self, buf: &mut String) {
+        buf.push_str("self.client.");
+        buf.push_str(self.inner_method_name);
+        if self.r#async {
+            buf.push_str("_async");
+        }
+        buf.push_str("(&");
+        buf.push_str(self.data_name);
+        if self.request.is_some() {
+            buf.push_str(", req");
+        }
+        buf.push_str(", opt)");
+    }
+}
+
+fn generate_spawn(buf: &mut String) {
+    buf.push_str(
+        "pub fn spawn<F>(&self, f: F) \
+         where F: ::std::future::Future<Output = ()> + Send + 'static {\
+         self.client.spawn(f)\
+         }\n",
+    );
+}
+
+fn generate_server(service: &Service, buf: &mut String) {
+    buf.push_str("pub trait ");
+    buf.push_str(&service.name);
+    buf.push_str(" {\n");
+    generate_server_methods(service, buf);
+    buf.push_str("}\n");
+
+    buf.push_str("pub fn create_");
+    buf.push_str(&to_snake_case(&service.name));
+    buf.push_str("<S: ");
+    buf.push_str(&service.name);
+    buf.push_str(" + Send + Clone + 'static>(s: S) -> ");
+    buf.push_str(&fq_grpc("Service"));
+    buf.push_str(" {\n");
+    buf.push_str("let mut builder = ::grpcio::ServiceBuilder::new();\n");
+
+    for method in &service.methods[0..service.methods.len() - 1] {
+        buf.push_str("let mut instance = s.clone();\n");
+        generate_method_bind(&service.name, method, buf);
+    }
+
+    buf.push_str("let mut instance = s;\n");
+    generate_method_bind(
+        &service.name,
+        &service.methods[service.methods.len() - 1],
+        buf,
+    );
+
+    buf.push_str("builder.build()\n");
+    buf.push_str("}\n");
+}
+
+fn generate_server_methods(service: &Service, buf: &mut String) {
+    for method in &service.methods {
+        let method_type = MethodType::from_method(method);
+        let request_arg = match method_type {
+            MethodType::Unary | MethodType::ServerStreaming => {
+                format!("req: {}", method.input_type)
+            }
+            MethodType::ClientStreaming | MethodType::Duplex => format!(
+                "stream: {}<{}>",
+                fq_grpc("RequestStream"),
+                method.input_type
+            ),
+        };
+        let response_type = match method_type {
+            MethodType::Unary => "UnarySink",
+            MethodType::ClientStreaming => "ClientStreamingSink",
+            MethodType::ServerStreaming => "ServerStreamingSink",
+            MethodType::Duplex => "DuplexSink",
+        };
+        generate_server_method(method, &request_arg, response_type, buf);
+    }
+}
+
+fn generate_server_method(
+    method: &Method,
+    request_arg: &str,
+    response_type: &str,
+    buf: &mut String,
+) {
+    buf.push_str("fn ");
+    buf.push_str(&method.name);
+    buf.push_str("(&mut self, ctx: ");
+    buf.push_str(&fq_grpc("RpcContext"));
+    buf.push_str(", _");
+    buf.push_str(request_arg);
+    buf.push_str(", sink: ");
+    buf.push_str(&fq_grpc(response_type));
+    buf.push('<');
+    buf.push_str(&method.output_type);
+    buf.push('>');
+    buf.push_str(") { grpcio::unimplemented_call!(ctx, sink) }\n");
+}
+
+fn generate_method_bind(service_name: &str, method: &Method, buf: &mut String) {
+    let add_name = match MethodType::from_method(method) {
+        MethodType::Unary => "add_unary_handler",
+        MethodType::ClientStreaming => "add_client_streaming_handler",
+        MethodType::ServerStreaming => "add_server_streaming_handler",
+        MethodType::Duplex => "add_duplex_streaming_handler",
+    };
+
+    buf.push_str("builder = builder.");
+    buf.push_str(add_name);
+    buf.push_str("(&");
+    buf.push_str(&const_method_name(service_name, method));
+    buf.push_str(", move |ctx, req, resp| instance.");
+    buf.push_str(&method.name);
+    buf.push_str("(ctx, req, resp));\n");
+}
+
+pub fn protoc_gen_grpc_rust_main() {
+    let mut args = env::args();
+    args.next();
+    let (mut protos, mut includes, mut out_dir): (Vec<_>, Vec<_>, _) = Default::default();
+    for arg in args {
+        if let Some(value) = arg.strip_prefix("--protos=") {
+            protos.extend(value.split(",").map(|s| s.to_string()));
+        } else if let Some(value) = arg.strip_prefix("--includes=") {
+            includes.extend(value.split(",").map(|s| s.to_string()));
+        } else if let Some(value) = arg.strip_prefix("--out-dir=") {
+            out_dir = value.to_string();
+        }
+    }
+    if protos.is_empty() {
+        panic!("should at least specify protos to generate");
+    }
+    compile_protos(&protos, &includes, &out_dir).unwrap();
+}

--- a/raft-rs/proto/protobuf-build/compiler/src/util.rs
+++ b/raft-rs/proto/protobuf-build/compiler/src/util.rs
@@ -1,0 +1,155 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::fmt;
+use std::str;
+
+// A struct that divide a name into serveral parts that meets rust's guidelines.
+struct NameSpliter<'a> {
+    name: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> NameSpliter<'a> {
+    fn new(s: &str) -> NameSpliter<'_> {
+        NameSpliter {
+            name: s.as_bytes(),
+            pos: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for NameSpliter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<&'a str> {
+        if self.pos == self.name.len() {
+            return None;
+        }
+        // skip all prefix '_'
+        while self.pos < self.name.len() && self.name[self.pos] == b'_' {
+            self.pos += 1;
+        }
+        let mut pos = self.name.len();
+        let mut upper_len = 0;
+        let mut meet_lower = false;
+        for i in self.pos..self.name.len() {
+            let c = self.name[i];
+            if c.is_ascii_uppercase() {
+                if meet_lower {
+                    // So it should be AaA or aaA
+                    pos = i;
+                    break;
+                }
+                upper_len += 1;
+            } else if c == b'_' {
+                pos = i;
+                break;
+            } else {
+                meet_lower = true;
+                if upper_len > 1 {
+                    // So it should be AAa
+                    pos = i - 1;
+                    break;
+                }
+            }
+        }
+        let s = str::from_utf8(&self.name[self.pos..pos]).unwrap();
+        self.pos = pos;
+        Some(s)
+    }
+}
+
+/// Adjust method name to follow rust-guidelines.
+pub fn to_snake_case(name: &str) -> String {
+    let mut snake_method_name = String::with_capacity(name.len());
+    for s in NameSpliter::new(name) {
+        snake_method_name.push_str(&s.to_lowercase());
+        snake_method_name.push('_');
+    }
+    snake_method_name.pop();
+    snake_method_name
+}
+
+#[cfg(feature = "protobuf-codec")]
+pub fn to_camel_case(name: &str) -> String {
+    let mut camel_case_name = String::with_capacity(name.len());
+    for s in NameSpliter::new(name) {
+        let mut chs = s.chars();
+        camel_case_name.extend(chs.next().unwrap().to_uppercase());
+        camel_case_name.push_str(&s[1..].to_lowercase());
+    }
+    camel_case_name
+}
+
+pub fn fq_grpc(item: &str) -> String {
+    format!("::grpcio::{item}")
+}
+
+pub enum MethodType {
+    Unary,
+    ClientStreaming,
+    ServerStreaming,
+    Duplex,
+}
+
+impl fmt::Display for MethodType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                MethodType::Unary => "MethodType::Unary",
+                MethodType::ClientStreaming => "MethodType::ClientStreaming",
+                MethodType::ServerStreaming => "MethodType::ServerStreaming",
+                MethodType::Duplex => "MethodType::Duplex",
+            }
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_snake_name() {
+        let cases = vec![
+            ("AsyncRequest", "async_request"),
+            ("asyncRequest", "async_request"),
+            ("async_request", "async_request"),
+            ("createID", "create_id"),
+            ("AsyncRClient", "async_r_client"),
+            ("CreateIDForReq", "create_id_for_req"),
+            ("Create_ID_For_Req", "create_id_for_req"),
+            ("Create_ID_For__Req", "create_id_for_req"),
+            ("ID", "id"),
+            ("id", "id"),
+        ];
+
+        for (origin, exp) in cases {
+            let res = super::to_snake_case(origin);
+            assert_eq!(res, exp);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "protobuf-codec")]
+    fn test_camel_name() {
+        let cases = vec![
+            ("AsyncRequest", "AsyncRequest"),
+            ("asyncRequest", "AsyncRequest"),
+            ("async_request", "AsyncRequest"),
+            ("createID", "CreateId"),
+            ("AsyncRClient", "AsyncRClient"),
+            ("async_r_client", "AsyncRClient"),
+            ("CreateIDForReq", "CreateIdForReq"),
+            ("Create_ID_For_Req", "CreateIdForReq"),
+            ("Create_ID_For__Req", "CreateIdForReq"),
+            ("ID", "Id"),
+            ("id", "Id"),
+        ];
+
+        for (origin, exp) in cases {
+            let res = super::to_camel_case(origin);
+            assert_eq!(res, exp);
+        }
+    }
+}

--- a/raft-rs/proto/protobuf-build/src/lib.rs
+++ b/raft-rs/proto/protobuf-build/src/lib.rs
@@ -25,6 +25,19 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::from_utf8;
 
+impl Builder {
+    /// Generate protobuf files using the appropriate codec.
+    ///
+    /// When both `prost-codec` and `protobuf-codec` are enabled simultaneously,
+    /// only the `prost-codec` generator runs (prost takes priority).
+    pub fn generate_files(&self) {
+        #[cfg(feature = "prost-codec")]
+        self.generate_files_prost();
+        #[cfg(all(feature = "protobuf-codec", not(feature = "prost-codec")))]
+        self.generate_files_protobuf();
+    }
+}
+
 // We use system protoc when its version matches,
 // otherwise use the protoc from bin which we bundle with the crate.
 fn get_protoc() -> String {

--- a/raft-rs/proto/protobuf-build/src/lib.rs
+++ b/raft-rs/proto/protobuf-build/src/lib.rs
@@ -219,7 +219,7 @@ impl Builder {
 
         let mut exports = String::new();
         for (module, file_name) in modules {
-            if cfg!(feature = "protobuf-codec") {
+            if cfg!(not(feature = "prost-codec")) {
                 if self.package_name.is_some() {
                     writeln!(exports, "pub use super::{}::*;", module).unwrap();
                 } else {

--- a/raft-rs/proto/protobuf-build/src/lib.rs
+++ b/raft-rs/proto/protobuf-build/src/lib.rs
@@ -219,13 +219,27 @@ impl Builder {
 
         let mut exports = String::new();
         for (module, file_name) in modules {
+            let wrapper_path = format!("{}/wrapper_{}.rs", self.out_dir, file_name);
+            let wrapper_exists = Path::new(&wrapper_path).exists();
+
             if cfg!(not(feature = "prost-codec")) {
-                if self.package_name.is_some() {
+                if wrapper_exists {
+                    // Wrapper exists (e.g., when both prost-codec and protobuf-codec
+                    // are enabled). Use nested module to include both files.
+                    writeln!(f, "pub mod {} {{", module).unwrap();
+                    writeln!(f, "    include!(\"{}.rs\");", file_name).unwrap();
+                    writeln!(f, "    include!(\"wrapper_{}.rs\");", file_name).unwrap();
+                    writeln!(f, "}}").unwrap();
+                    if self.package_name.is_some() {
+                        writeln!(exports, "pub use super::{}::*;", module).unwrap();
+                    }
+                } else if self.package_name.is_some() {
                     writeln!(exports, "pub use super::{}::*;", module).unwrap();
+                    writeln!(f, "mod {};", module).unwrap();
                 } else {
                     writeln!(f, "pub ").unwrap();
+                    writeln!(f, "mod {};", module).unwrap();
                 }
-                writeln!(f, "mod {};", module).unwrap();
                 continue;
             }
 
@@ -235,7 +249,7 @@ impl Builder {
                 level += 1;
             }
             writeln!(f, "include!(\"{}.rs\");", file_name,).unwrap();
-            if Path::new(&format!("{}/wrapper_{}.rs", self.out_dir, file_name)).exists() {
+            if wrapper_exists {
                 writeln!(f, "include!(\"wrapper_{}.rs\");", file_name,).unwrap();
             }
             writeln!(f, "{}", "}\n".repeat(level)).unwrap();

--- a/raft-rs/proto/protobuf-build/src/prost_impl.rs
+++ b/raft-rs/proto/protobuf-build/src/prost_impl.rs
@@ -2,7 +2,7 @@ use crate::wrapper::WrapperGen;
 use crate::{get_protoc, Builder};
 
 impl Builder {
-    pub fn generate_files(&self) {
+    pub fn generate_files_prost(&self) {
         std::env::set_var("PROTOC", get_protoc());
 
         #[cfg(feature = "grpcio-prost-codec")]

--- a/raft-rs/proto/protobuf-build/src/protobuf_impl.rs
+++ b/raft-rs/proto/protobuf-build/src/protobuf_impl.rs
@@ -6,7 +6,12 @@ use std::path::Path;
 use std::process::Command;
 
 use protobuf::Message;
+use protobuf_codegen::CustomizeCallback;
+use protobuf_parse::ProtoPathBuf;
 use regex::Regex;
+
+struct DefaultCustomizeCallback;
+impl CustomizeCallback for DefaultCustomizeCallback {}
 
 use crate::get_protoc;
 use crate::Builder;
@@ -51,14 +56,21 @@ impl Builder {
             );
         }
 
-        protobuf_codegen::gen_and_write(
-            desc.get_file(),
-            &files_to_generate,
+        let proto_files = files_to_generate
+            .iter()
+            .map(|f| ProtoPathBuf::new(f.clone()).unwrap())
+            .collect::<Vec<_>>();
+
+        protobuf_codegen::gen_and_write::gen_and_write(
+            &desc.file,
+            "protoc",
+            &proto_files,
             Path::new(&self.out_dir),
-            &protobuf_codegen::Customize::default(),
+            &protobuf_codegen::Customize::default().generate_accessors(true),
+            &DefaultCustomizeCallback,
         )
         .unwrap();
-        self.generate_grpcio(desc.get_file(), &files_to_generate);
+        self.generate_grpcio(&desc.file, &files_to_generate);
         self.import_grpcio();
         self.replace_read_unknown_fields();
     }

--- a/raft-rs/proto/protobuf-build/src/protobuf_impl.rs
+++ b/raft-rs/proto/protobuf-build/src/protobuf_impl.rs
@@ -17,7 +17,7 @@ use crate::get_protoc;
 use crate::Builder;
 
 impl Builder {
-    pub fn generate_files(&self) {
+    pub fn generate_files_protobuf(&self) {
         let mut cmd = Command::new(get_protoc());
         let desc_file = format!("{}/mod.desc", self.out_dir);
         for i in &self.includes {

--- a/raft-rs/proto/protobuf-build/src/wrapper.rs
+++ b/raft-rs/proto/protobuf-build/src/wrapper.rs
@@ -419,8 +419,10 @@ impl FieldKind {
             }
             FieldKind::Message => {
                 let unboxed_type = unwrap_type(ty, "Box");
-                if ty != &unboxed_type {
-                    result.ref_ty = RefType::Deref(unboxed_type.into_token_stream().to_string());
+                let ty_str = ty.into_token_stream().to_string();
+                let unboxed_str = unboxed_type.into_token_stream().to_string();
+                if ty_str != unboxed_str {
+                    result.ref_ty = RefType::Deref(unboxed_str);
                 }
             }
             FieldKind::Int => {

--- a/raft-rs/proto/protobuf-build/src/wrapper.rs
+++ b/raft-rs/proto/protobuf-build/src/wrapper.rs
@@ -496,6 +496,7 @@ impl FieldKind {
                 result.clear = Some("0".to_owned());
                 result.set = Some("v as i32".to_owned());
                 result.enum_set = true;
+                result.prost_has_unprefixed = true;
                 result.get = Some(format!(
                     "match {}::from_i32(self.{}) {{\
                         Some(e) => e,
@@ -556,6 +557,8 @@ struct FieldMethods {
     mt: MethodKind,
     take: Option<String>,
     deprecated: bool,
+    /// prost-derive 0.11 generates un-prefixed methods for bare (non-Option) enum fields
+    prost_has_unprefixed: bool,
 }
 
 impl FieldMethods {
@@ -578,6 +581,7 @@ impl FieldMethods {
             mt: MethodKind::None,
             take: None,
             deprecated,
+            prost_has_unprefixed: false,
         }
     }
 
@@ -638,11 +642,22 @@ impl FieldMethods {
         }
         // get_*
         match &self.get {
-            Some(s) => writeln!(
-                buf,
-                "{}#[inline] pub fn get_{}(&self) -> {} {{ {} }}",
-                deprecated, self.unesc_base, ref_ty, s
-            )?,
+            Some(s) => {
+                writeln!(
+                    buf,
+                    "{}#[inline] pub fn get_{}(&self) -> {} {{ {} }}",
+                    deprecated, self.unesc_base, ref_ty, s
+                )?;
+                // Also generate an un-prefixed accessor for compatibility with protobuf 3.x
+                // but only if prost-derive doesn't already generate one (e.g., for enum fields)
+                if !self.prost_has_unprefixed {
+                    writeln!(
+                        buf,
+                        "{}#[inline] pub fn {}(&self) -> {} {{ self.get_{}() }}",
+                        deprecated, self.unesc_base, ref_ty, self.unesc_base
+                    )?;
+                }
+            }
             None => {
                 if gen_opt.contains(GenOpt::TRIVIAL_GET) {
                     let rf = match &self.ref_ty {
@@ -653,7 +668,15 @@ impl FieldMethods {
                         buf,
                         "{}#[inline] pub fn get_{}(&self) -> {} {{ {}self.{} }}",
                         deprecated, self.unesc_base, ref_ty, rf, self.name
-                    )?
+                    )?;
+                    // Also generate an un-prefixed accessor for compatibility with protobuf 3.x
+                    if !self.prost_has_unprefixed {
+                        writeln!(
+                            buf,
+                            "{}#[inline] pub fn {}(&self) -> {} {{ self.get_{}() }}",
+                            deprecated, self.unesc_base, ref_ty, self.unesc_base
+                        )?;
+                    }
                 }
             }
         }
@@ -736,7 +759,7 @@ fn type_in_expr_context(s: &str) -> String {
     let last_segment = parsed.path.segments.last_mut().unwrap();
     if !last_segment.arguments.is_empty() {
         if let PathArguments::AngleBracketed(ref mut a) = last_segment.arguments {
-            if a.colon2_token == None {
+            if a.colon2_token.is_none() {
                 a.colon2_token = Some(Token![::](Span::call_site()));
             }
         }

--- a/raft-rs/proto/protobuf-build/tests/Cargo.toml
+++ b/raft-rs/proto/protobuf-build/tests/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 build = "build.rs"
 
 [features]
-protobuf-codec = ["protobuf-build/grpcio-protobuf-codec"]
-prost-codec = ["protobuf-build/grpcio-prost-codec"]
+protobuf-codec = ["rmqtt-protobuf-build/grpcio-protobuf-codec"]
+prost-codec = ["rmqtt-protobuf-build/grpcio-prost-codec"]
 
 [dependencies]
 protobuf = "3.7.2"
@@ -17,4 +17,4 @@ prost-derive = "0.11"
 lazy_static = "1.4"
 
 [build-dependencies]
-protobuf-build = { path = "../", default-features = false }
+rmqtt-protobuf-build = { path = "../", default-features = false }

--- a/raft-rs/proto/protobuf-build/tests/build.rs
+++ b/raft-rs/proto/protobuf-build/tests/build.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 PingCAP, Inc.
 
-use protobuf_build::Builder;
+use rmqtt_protobuf_build::Builder;
 
 fn main() {
     Builder::new().search_dir_for_protos("proto").generate()

--- a/raft-rs/proto/src/confchange.rs
+++ b/raft-rs/proto/src/confchange.rs
@@ -54,7 +54,7 @@ pub fn stringify_conf_change(ccs: &[ConfChangeSingle]) -> String {
         if i > 0 {
             s.push(' ');
         }
-        match cc.get_change_type() {
+        match cc.change_type() {
             ConfChangeType::AddNode => s.push('v'),
             ConfChangeType::AddLearnerNode => s.push('l'),
             ConfChangeType::RemoveNode => s.push('r'),
@@ -83,7 +83,7 @@ impl ConfChangeI for ConfChange {
     #[inline]
     fn into_v2(mut self) -> ConfChangeV2 {
         let mut cc = ConfChangeV2::default();
-        let single = new_conf_change_single(self.node_id, self.get_change_type());
+        let single = new_conf_change_single(self.node_id, self.change_type());
         cc.mut_changes().push(single);
         cc.set_context(self.take_context());
         cc
@@ -131,8 +131,8 @@ impl ConfChangeV2 {
         // base config (i.e. two voters are turned into learners in the process of
         // applying the conf change). In practice, these distinctions should not
         // matter, so we keep it simple and use Joint Consensus liberally.
-        if self.get_transition() != ConfChangeTransition::Auto || self.changes.len() > 1 {
-            match self.get_transition() {
+        if self.transition() != ConfChangeTransition::Auto || self.changes.len() > 1 {
+            match self.transition() {
                 ConfChangeTransition::Auto | ConfChangeTransition::Implicit => Some(true),
                 ConfChangeTransition::Explicit => Some(false),
             }
@@ -146,6 +146,6 @@ impl ConfChangeV2 {
     /// This is the case if the ConfChangeV2 is zero, with the possible exception of
     /// the Context field.
     pub fn leave_joint(&self) -> bool {
-        self.get_transition() == ConfChangeTransition::Auto && self.changes.is_empty()
+        self.transition() == ConfChangeTransition::Auto && self.changes.is_empty()
     }
 }

--- a/raft-rs/proto/src/confstate.rs
+++ b/raft-rs/proto/src/confstate.rs
@@ -23,18 +23,18 @@ pub fn conf_state_eq(lhs: &ConfState, rhs: &ConfState) -> bool {
     // different. In most case, only one hash algorithm is used. Insert orders
     // should be the same due to the raft protocol. So in most case, they can
     // be compared directly.
-    if lhs.get_voters() == rhs.get_voters()
-        && lhs.get_learners() == rhs.get_learners()
-        && lhs.get_voters_outgoing() == rhs.get_voters_outgoing()
-        && lhs.get_learners_next() == rhs.get_learners_next()
+    if lhs.voters == rhs.voters
+        && lhs.learners == rhs.learners
+        && lhs.voters_outgoing == rhs.voters_outgoing
+        && lhs.learners_next == rhs.learners_next
         && lhs.auto_leave == rhs.auto_leave
     {
         return true;
     }
 
-    eq_without_order(lhs.get_voters(), rhs.get_voters())
-        && eq_without_order(lhs.get_learners(), rhs.get_learners())
-        && eq_without_order(lhs.get_voters_outgoing(), rhs.get_voters_outgoing())
-        && eq_without_order(lhs.get_learners_next(), rhs.get_learners_next())
+    eq_without_order(&lhs.voters, &rhs.voters)
+        && eq_without_order(&lhs.learners, &rhs.learners)
+        && eq_without_order(&lhs.voters_outgoing, &rhs.voters_outgoing)
+        && eq_without_order(&lhs.learners_next, &rhs.learners_next)
         && lhs.auto_leave == rhs.auto_leave
 }

--- a/raft-rs/proto/src/lib.rs
+++ b/raft-rs/proto/src/lib.rs
@@ -26,7 +26,7 @@ mod protos {
     impl Snapshot {
         /// For a given snapshot, determine if it's empty or not.
         pub fn is_empty(&self) -> bool {
-            self.get_metadata().index == 0
+            self.metadata.as_ref().map_or(true, |m| m.index == 0)
         }
     }
 }
@@ -48,8 +48,8 @@ pub mod util {
     {
         fn from((voters, learners): (Iter1, Iter2)) -> Self {
             let mut conf_state = ConfState::default();
-            conf_state.mut_voters().extend(voters.into_iter());
-            conf_state.mut_learners().extend(learners.into_iter());
+            conf_state.mut_voters().extend(voters);
+            conf_state.mut_learners().extend(learners);
             conf_state
         }
     }

--- a/raft-rs/src/confchange/changer.rs
+++ b/raft-rs/src/confchange/changer.rs
@@ -172,7 +172,7 @@ impl Changer<'_> {
                 // here to ignore these.
                 continue;
             }
-            match cc.get_change_type() {
+            match cc.change_type() {
                 ConfChangeType::AddNode => self.make_voter(cfg, prs, cc.node_id),
                 ConfChangeType::AddLearnerNode => self.make_learner(cfg, prs, cc.node_id),
                 ConfChangeType::RemoveNode => self.remove(cfg, prs, cc.node_id),

--- a/raft-rs/src/confchange/restore.rs
+++ b/raft-rs/src/confchange/restore.rs
@@ -41,7 +41,7 @@ fn to_conf_change_single(cs: &ConfState) -> (Vec<ConfChangeSingle>, Vec<ConfChan
     // as desired.
     let mut incoming = Vec::new();
     let mut outgoing = Vec::new();
-    for id in cs.get_voters_outgoing() {
+    for id in &cs.voters_outgoing {
         // If there are outgoing voters, first add them one by one so that the
         // (non-joint) config has them all.
         outgoing.push(raft_proto::new_conf_change_single(
@@ -54,20 +54,20 @@ fn to_conf_change_single(cs: &ConfState) -> (Vec<ConfChangeSingle>, Vec<ConfChan
     // (which will apply on top of the config created by the outgoing slice).
 
     // First, we'll remove all of the outgoing voters.
-    for id in cs.get_voters_outgoing() {
+    for id in &cs.voters_outgoing {
         incoming.push(raft_proto::new_conf_change_single(
             *id,
             ConfChangeType::RemoveNode,
         ));
     }
     // Then we'll add the incoming voters and learners.
-    for id in cs.get_voters() {
+    for id in &cs.voters {
         incoming.push(raft_proto::new_conf_change_single(
             *id,
             ConfChangeType::AddNode,
         ));
     }
-    for id in cs.get_learners() {
+    for id in &cs.learners {
         incoming.push(raft_proto::new_conf_change_single(
             *id,
             ConfChangeType::AddLearnerNode,
@@ -75,7 +75,7 @@ fn to_conf_change_single(cs: &ConfState) -> (Vec<ConfChangeSingle>, Vec<ConfChan
     }
     // Same for LearnersNext; these are nodes we want to be learners but which
     // are currently voters in the outgoing config.
-    for id in cs.get_learners_next() {
+    for id in &cs.learners_next {
         incoming.push(raft_proto::new_conf_change_single(
             *id,
             ConfChangeType::AddLearnerNode,

--- a/raft-rs/src/errors.rs
+++ b/raft-rs/src/errors.rs
@@ -50,7 +50,7 @@ pub enum Error {
 }
 
 impl PartialEq for Error {
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::match_same_arms))]
+    #[allow(clippy::match_same_arms)]
     fn eq(&self, other: &Error) -> bool {
         match (self, other) {
             (Error::StepPeerNotFound, Error::StepPeerNotFound) => true,
@@ -90,7 +90,7 @@ pub enum StorageError {
 }
 
 impl PartialEq for StorageError {
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::match_same_arms))]
+    #[allow(clippy::match_same_arms)]
     fn eq(&self, other: &StorageError) -> bool {
         matches!(
             (self, other),
@@ -146,8 +146,8 @@ mod tests {
             Error::ConfigInvalid(String::from("other error"))
         );
         assert_eq!(
-            Error::from(io::Error::new(io::ErrorKind::Other, "oh no!")),
-            Error::from(io::Error::new(io::ErrorKind::Other, "oh yes!"))
+            Error::from(io::Error::other("oh no!")),
+            Error::from(io::Error::other("oh yes!"))
         );
         assert_ne!(
             Error::StepPeerNotFound,

--- a/raft-rs/src/lib.rs
+++ b/raft-rs/src/lib.rs
@@ -292,7 +292,7 @@ need to update the applied index and resume `apply` later:
             continue;
         }
 
-        match entry.get_entry_type() {
+        match entry.entry_type() {
             EntryType::EntryNormal => handle_normal(entry),
             // It's recommended to always use `EntryType::EntryConfChangeV2.
             EntryType::EntryConfChange => handle_conf_change(entry),
@@ -470,14 +470,15 @@ This process is a two-phase process, during the midst of it the peer group's lea
 **two independent, possibly overlapping peer sets**.
 
 > **Note:** In order to maintain resiliency guarantees  (progress while a majority of both peer sets is
-active), it is recommended to wait until the entire peer group has exited the transition phase
-before taking old, removed peers offline.
+> active), it is recommended to wait until the entire peer group has exited the transition phase
+> before taking old, removed peers offline.
 
 */
 
-#![cfg_attr(not(feature = "cargo-clippy"), allow(unknown_lints))]
+#![cfg_attr(not(clippy), allow(unknown_lints))]
 #![allow(unexpected_cfgs)]
 #![deny(clippy::all)]
+#![allow(clippy::doc_lazy_continuation, clippy::doc_overindented_list_items)]
 #![deny(missing_docs)]
 #![recursion_limit = "128"]
 // This is necessary to support prost and rust-protobuf at the same time.
@@ -508,6 +509,7 @@ mod config;
 mod errors;
 mod log_unstable;
 mod quorum;
+/// The raft consensus algorithm implementation.
 #[cfg(test)]
 pub mod raft;
 #[cfg(not(test))]
@@ -576,23 +578,19 @@ pub mod prelude {
 #[cfg(any(test, feature = "default-logger"))]
 pub fn default_logger() -> slog::Logger {
     use slog::{o, Drain};
-    use std::sync::{Mutex, Once};
+    use std::sync::Mutex;
 
-    static LOGGER_INITIALIZED: Once = Once::new();
-    static mut LOGGER: Option<slog::Logger> = None;
+    static LOGGER: std::sync::OnceLock<slog::Logger> = std::sync::OnceLock::new();
 
-    let logger = unsafe {
-        LOGGER_INITIALIZED.call_once(|| {
-            let decorator = slog_term::TermDecorator::new().build();
-            let drain = slog_term::CompactFormat::new(decorator).build();
-            let drain = slog_envlogger::new(drain);
-            LOGGER = Some(slog::Logger::root(Mutex::new(drain).fuse(), o!()));
-        });
-        LOGGER.as_ref().unwrap()
-    };
+    let logger = LOGGER.get_or_init(|| {
+        let decorator = slog_term::TermDecorator::new().build();
+        let drain = slog_term::CompactFormat::new(decorator).build();
+        let drain = slog_envlogger::new(drain);
+        slog::Logger::root(Mutex::new(drain).fuse(), o!())
+    });
     if let Some(case) = std::thread::current()
         .name()
-        .and_then(|v| v.split(':').last())
+        .and_then(|v| v.split(':').next_back())
     {
         logger.new(o!("case" => case.to_string()))
     } else {

--- a/raft-rs/src/log_unstable.rs
+++ b/raft-rs/src/log_unstable.rs
@@ -57,15 +57,13 @@ impl Unstable {
     /// Returns the index of the first possible entry in entries
     /// if it has a snapshot.
     pub fn maybe_first_index(&self) -> Option<u64> {
-        self.snapshot
-            .as_ref()
-            .map(|snap| snap.get_metadata().index + 1)
+        self.snapshot.as_ref().map(|snap| snap.metadata().index + 1)
     }
 
     /// Returns the last index if it has at least one unstable entry or snapshot.
     pub fn maybe_last_index(&self) -> Option<u64> {
         match self.entries.len() {
-            0 => self.snapshot.as_ref().map(|snap| snap.get_metadata().index),
+            0 => self.snapshot.as_ref().map(|snap| snap.metadata().index),
             len => Some(self.offset + len as u64 - 1),
         }
     }
@@ -74,7 +72,7 @@ impl Unstable {
     pub fn maybe_term(&self, idx: u64) -> Option<u64> {
         if idx < self.offset {
             let snapshot = self.snapshot.as_ref()?;
-            let meta = snapshot.get_metadata();
+            let meta = snapshot.metadata();
             if idx == meta.index {
                 Some(meta.term)
             } else {
@@ -96,17 +94,17 @@ impl Unstable {
         // The snapshot must be stabled before entries
         assert!(self.snapshot.is_none());
         if let Some(entry) = self.entries.last() {
-            if entry.get_index() != index || entry.get_term() != term {
+            if entry.index != index || entry.term != term {
                 fatal!(
                     self.logger,
                     "the last one of unstable.slice has different index {} and term {}, expect {} {}",
-                    entry.get_index(),
-                    entry.get_term(),
+                    entry.index,
+                    entry.term,
                     index,
                     term
                 );
             }
-            self.offset = entry.get_index() + 1;
+            self.offset = entry.index + 1;
             self.entries.clear();
             self.entries_size = 0;
         } else {
@@ -122,11 +120,11 @@ impl Unstable {
     /// Clears the unstable snapshot.
     pub fn stable_snap(&mut self, index: u64) {
         if let Some(snap) = &self.snapshot {
-            if snap.get_metadata().index != index {
+            if snap.metadata().index != index {
                 fatal!(
                     self.logger,
                     "unstable.snap has different index {}, expect {}",
-                    snap.get_metadata().index,
+                    snap.metadata().index,
                     index
                 );
             }
@@ -144,7 +142,7 @@ impl Unstable {
     pub fn restore(&mut self, snap: Snapshot) {
         self.entries.clear();
         self.entries_size = 0;
-        self.offset = snap.get_metadata().index + 1;
+        self.offset = snap.metadata().index + 1;
         self.snapshot = Some(snap);
     }
 
@@ -381,7 +379,7 @@ mod test {
         let s = new_snapshot(6, 2);
         u.restore(s.clone());
 
-        assert_eq!(u.offset, s.get_metadata().index + 1);
+        assert_eq!(u.offset, s.metadata().index + 1);
         assert!(u.entries.is_empty());
         assert_eq!(u.entries_size, 0);
         assert_eq!(u.snapshot.unwrap(), s);

--- a/raft-rs/src/quorum/majority.rs
+++ b/raft-rs/src/quorum/majority.rs
@@ -7,7 +7,7 @@ use std::collections::hash_set::Iter;
 use std::fmt::Formatter;
 use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
-use std::{cmp, slice, u64};
+use std::{cmp, slice};
 
 /// A set of IDs that uses majority quorums to make decisions.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/raft-rs/src/raft.rs
+++ b/raft-rs/src/raft.rs
@@ -58,9 +58,10 @@ pub const CAMPAIGN_ELECTION: &[u8] = b"CampaignElection";
 pub const CAMPAIGN_TRANSFER: &[u8] = b"CampaignTransfer";
 
 /// The role of the node.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum StateRole {
     /// The node is a follower of the leader.
+    #[default]
     Follower,
     /// The node could become a leader.
     Candidate,
@@ -68,12 +69,6 @@ pub enum StateRole {
     Leader,
     /// The node could become a candidate, if `prevote` is enabled.
     PreCandidate,
-}
-
-impl Default for StateRole {
-    fn default() -> StateRole {
-        StateRole::Follower
-    }
 }
 
 /// A constant represents invalid id of raft.
@@ -118,7 +113,7 @@ impl UncommittedState {
             return true;
         }
 
-        let size: usize = ents.iter().map(|ent| ent.get_data().len()).sum();
+        let size: usize = ents.iter().map(|ent| ent.data.len()).sum();
 
         // 1. we should never drop an entry without any data(eg. leader election)
         // 2. we should allow at least one uncommitted entry
@@ -144,7 +139,7 @@ impl UncommittedState {
         let size: usize = ents
             .iter()
             .skip_while(|ent| ent.index <= self.last_log_tail_index)
-            .map(|ent| ent.get_data().len())
+            .map(|ent| ent.data.len())
             .sum();
 
         if size > self.uncommitted_size {
@@ -586,14 +581,14 @@ impl<T: Storage> Raft<T> {
     pub fn commit_to_current_term(&self) -> bool {
         self.raft_log
             .term(self.raft_log.committed)
-            .map_or(false, |t| t == self.term)
+            .is_ok_and(|t| t == self.term)
     }
 
     /// Checks if logs are applied to current term.
     pub fn apply_to_current_term(&self) -> bool {
         self.raft_log
             .term(self.raft_log.applied)
-            .map_or(false, |t| t == self.term)
+            .is_ok_and(|t| t == self.term)
     }
 
     /// Set `max_committed_size_per_ready` to `size`.
@@ -620,10 +615,10 @@ impl<T: Storage> RaftCore<T> {
         if m.from == INVALID_ID {
             m.from = self.id;
         }
-        if m.get_msg_type() == MessageType::MsgRequestVote
-            || m.get_msg_type() == MessageType::MsgRequestPreVote
-            || m.get_msg_type() == MessageType::MsgRequestVoteResponse
-            || m.get_msg_type() == MessageType::MsgRequestPreVoteResponse
+        if m.msg_type() == MessageType::MsgRequestVote
+            || m.msg_type() == MessageType::MsgRequestPreVote
+            || m.msg_type() == MessageType::MsgRequestVoteResponse
+            || m.msg_type() == MessageType::MsgRequestPreVoteResponse
         {
             if m.term == 0 {
                 // All {pre-,}campaign messages need to have the term set when
@@ -641,7 +636,7 @@ impl<T: Storage> RaftCore<T> {
                 fatal!(
                     self.logger,
                     "term should be set when sending {:?}",
-                    m.get_msg_type()
+                    m.msg_type()
                 );
             }
         } else {
@@ -649,7 +644,7 @@ impl<T: Storage> RaftCore<T> {
                 fatal!(
                     self.logger,
                     "term should not be set when sending {:?} (was {})",
-                    m.get_msg_type(),
+                    m.msg_type(),
                     m.term
                 );
             }
@@ -657,14 +652,13 @@ impl<T: Storage> RaftCore<T> {
             // proposals are a way to forward to the leader and
             // should be treated as local message.
             // MsgReadIndex is also forwarded to leader.
-            if m.get_msg_type() != MessageType::MsgPropose
-                && m.get_msg_type() != MessageType::MsgReadIndex
+            if m.msg_type() != MessageType::MsgPropose && m.msg_type() != MessageType::MsgReadIndex
             {
                 m.term = self.term;
             }
         }
-        if m.get_msg_type() == MessageType::MsgRequestVote
-            || m.get_msg_type() == MessageType::MsgRequestPreVote
+        if m.msg_type() == MessageType::MsgRequestVote
+            || m.msg_type() == MessageType::MsgRequestPreVote
         {
             if self.priority > 0 {
                 m.deprecated_priority = self.priority as u64;
@@ -699,10 +693,10 @@ impl<T: Storage> RaftCore<T> {
             fatal!(self.logger, "unexpected error: {:?}", e);
         }
         let snapshot = snapshot_r.unwrap();
-        if snapshot.get_metadata().index == 0 {
+        if snapshot.metadata().index == 0 {
             fatal!(self.logger, "need non-empty snapshot");
         }
-        let (sindex, sterm) = (snapshot.get_metadata().index, snapshot.get_metadata().term);
+        let (sindex, sterm) = (snapshot.metadata().index, snapshot.metadata().term);
         m.set_snapshot(snapshot);
         debug!(
             self.logger,
@@ -753,7 +747,7 @@ impl<T: Storage> RaftCore<T> {
         // will append the entries to the existing MsgAppend
         let mut is_batched = false;
         for msg in msgs {
-            if msg.get_msg_type() == MessageType::MsgAppend && msg.to == to {
+            if msg.msg_type() == MessageType::MsgAppend && msg.to == to {
                 if !ents.is_empty() {
                     if !util::is_continuous_ents(msg, ents) {
                         return is_batched;
@@ -822,7 +816,7 @@ impl<T: Storage> RaftCore<T> {
                     aggressively: !allow_empty,
                 }),
             );
-            if !allow_empty && ents.as_ref().ok().map_or(true, |e| e.is_empty()) {
+            if !allow_empty && ents.as_ref().ok().is_none_or(|e| e.is_empty()) {
                 return false;
             }
             let term = self.raft_log.term(pr.next_idx - 1);
@@ -922,7 +916,7 @@ impl<T: Storage> Raft<T> {
         self.bcast_heartbeat_with_ctx(ctx)
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_pass_by_value))]
+    #[allow(clippy::needless_pass_by_value)]
     fn bcast_heartbeat_with_ctx(&mut self, ctx: Option<Vec<u8>>) {
         let self_id = self.id;
         let core = &mut self.r;
@@ -1249,8 +1243,8 @@ impl<T: Storage> Raft<T> {
     fn num_pending_conf(&self, ents: &[Entry]) -> usize {
         ents.iter()
             .filter(|e| {
-                e.get_entry_type() == EntryType::EntryConfChange
-                    || e.get_entry_type() == EntryType::EntryConfChangeV2
+                e.entry_type() == EntryType::EntryConfChange
+                    || e.entry_type() == EntryType::EntryConfChangeV2
             })
             .count()
     }
@@ -1327,8 +1321,8 @@ impl<T: Storage> Raft<T> {
         if m.term == 0 {
             // local message
         } else if m.term > self.term {
-            if m.get_msg_type() == MessageType::MsgRequestVote
-                || m.get_msg_type() == MessageType::MsgRequestPreVote
+            if m.msg_type() == MessageType::MsgRequestVote
+                || m.msg_type() == MessageType::MsgRequestPreVote
             {
                 let force = m.context == CAMPAIGN_TRANSFER;
                 let in_lease = self.check_quorum
@@ -1354,15 +1348,15 @@ impl<T: Storage> Raft<T> {
                         msg_index = m.index;
                         "term" => self.term,
                         "remaining ticks" => self.election_timeout - self.election_elapsed,
-                        "msg type" => ?m.get_msg_type(),
+                        "msg type" => ?m.msg_type(),
                     );
 
                     return Ok(());
                 }
             }
 
-            if m.get_msg_type() == MessageType::MsgRequestPreVote
-                || (m.get_msg_type() == MessageType::MsgRequestPreVoteResponse && !m.reject)
+            if m.msg_type() == MessageType::MsgRequestPreVote
+                || (m.msg_type() == MessageType::MsgRequestPreVoteResponse && !m.reject)
             {
                 // For a pre-vote request:
                 // Never change our term in response to a pre-vote request.
@@ -1380,11 +1374,11 @@ impl<T: Storage> Raft<T> {
                     from = m.from;
                     "term" => self.term,
                     "message_term" => m.term,
-                    "msg type" => ?m.get_msg_type(),
+                    "msg type" => ?m.msg_type(),
                 );
-                if m.get_msg_type() == MessageType::MsgAppend
-                    || m.get_msg_type() == MessageType::MsgHeartbeat
-                    || m.get_msg_type() == MessageType::MsgSnapshot
+                if m.msg_type() == MessageType::MsgAppend
+                    || m.msg_type() == MessageType::MsgHeartbeat
+                    || m.msg_type() == MessageType::MsgSnapshot
                 {
                     self.become_follower(m.term, m.from);
                 } else {
@@ -1393,8 +1387,8 @@ impl<T: Storage> Raft<T> {
             }
         } else if m.term < self.term {
             if (self.check_quorum || self.pre_vote)
-                && (m.get_msg_type() == MessageType::MsgHeartbeat
-                    || m.get_msg_type() == MessageType::MsgAppend)
+                && (m.msg_type() == MessageType::MsgHeartbeat
+                    || m.msg_type() == MessageType::MsgAppend)
             {
                 // We have received messages from a leader at a lower term. It is possible
                 // that these messages were simply delayed in the network, but this could
@@ -1419,7 +1413,7 @@ impl<T: Storage> Raft<T> {
                 // fresh election. This can be prevented with Pre-Vote phase.
                 let to_send = new_message(m.from, MessageType::MsgAppendResponse, None);
                 self.r.send(to_send, &mut self.msgs);
-            } else if m.get_msg_type() == MessageType::MsgRequestPreVote {
+            } else if m.msg_type() == MessageType::MsgRequestPreVote {
                 // Before pre_vote enable, there may be a receiving candidate with higher term,
                 // but less log. After update to pre_vote, the cluster may deadlock if
                 // we drop messages with a lower term.
@@ -1430,7 +1424,7 @@ impl<T: Storage> Raft<T> {
                     self.raft_log.last_term(),
                     self.raft_log.last_index(),
                     self.vote,
-                    m.get_msg_type(),
+                    m.msg_type(),
                     m.from,
                     m.log_term,
                     m.index,
@@ -1448,7 +1442,7 @@ impl<T: Storage> Raft<T> {
                     "ignored a message with lower term from {from}",
                     from = m.from;
                     "term" => self.term,
-                    "msg type" => ?m.get_msg_type(),
+                    "msg type" => ?m.msg_type(),
                     "msg term" => m.term
                 );
             }
@@ -1458,7 +1452,7 @@ impl<T: Storage> Raft<T> {
         #[cfg(feature = "failpoints")]
         fail_point!("before_step");
 
-        match m.get_msg_type() {
+        match m.msg_type() {
             MessageType::MsgHup => self.hup(false),
             MessageType::MsgRequestVote | MessageType::MsgRequestPreVote => {
                 // We can vote if this is a repeat of a vote we've already cast...
@@ -1466,7 +1460,7 @@ impl<T: Storage> Raft<T> {
                     // ...we haven't voted and we don't think there's a leader yet in this term...
                     (self.vote == INVALID_ID && self.leader_id == INVALID_ID) ||
                     // ...or this is a PreVote for a future term...
-                    (m.get_msg_type() == MessageType::MsgRequestPreVote && m.term > self.term);
+                    (m.msg_type() == MessageType::MsgRequestPreVote && m.term > self.term);
                 // ...and we believe the candidate is up to date.
                 if can_vote
                     && self.raft_log.is_up_to_date(m.index, m.log_term)
@@ -1482,20 +1476,18 @@ impl<T: Storage> Raft<T> {
                     // The term in the original message and current local term are the
                     // same in the case of regular votes, but different for pre-votes.
                     self.log_vote_approve(&m);
-                    let mut to_send =
-                        new_message(m.from, vote_resp_msg_type(m.get_msg_type()), None);
+                    let mut to_send = new_message(m.from, vote_resp_msg_type(m.msg_type()), None);
                     to_send.reject = false;
                     to_send.term = m.term;
                     self.r.send(to_send, &mut self.msgs);
-                    if m.get_msg_type() == MessageType::MsgRequestVote {
+                    if m.msg_type() == MessageType::MsgRequestVote {
                         // Only record real votes.
                         self.election_elapsed = 0;
                         self.vote = m.from;
                     }
                 } else {
                     self.log_vote_reject(&m);
-                    let mut to_send =
-                        new_message(m.from, vote_resp_msg_type(m.get_msg_type()), None);
+                    let mut to_send = new_message(m.from, vote_resp_msg_type(m.msg_type()), None);
                     to_send.reject = true;
                     to_send.term = self.term;
                     let (commit, commit_term) = self.raft_log.commit_info();
@@ -1586,7 +1578,7 @@ impl<T: Storage> Raft<T> {
             msg_term = m.log_term,
             msg_index = m.index,
             term = self.term;
-            "msg type" => ?m.get_msg_type(),
+            "msg type" => ?m.msg_type(),
         );
     }
 
@@ -1602,7 +1594,7 @@ impl<T: Storage> Raft<T> {
             msg_term = m.log_term,
             msg_index = m.index,
             term = self.term;
-            "msg type" => ?m.get_msg_type(),
+            "msg type" => ?m.msg_type(),
         );
     }
 
@@ -1789,7 +1781,7 @@ impl<T: Storage> Raft<T> {
                     pr.become_probe();
                 }
             }
-            ProgressState::Replicate => pr.ins.free_to(m.get_index()),
+            ProgressState::Replicate => pr.ins.free_to(m.index),
         }
 
         if self.maybe_commit() {
@@ -2004,7 +1996,7 @@ impl<T: Storage> Raft<T> {
 
     fn step_leader(&mut self, mut m: Message) -> Result<()> {
         // These message types do not require any progress for m.From.
-        match m.get_msg_type() {
+        match m.msg_type() {
             MessageType::MsgBeat => {
                 self.bcast_heartbeat();
                 return Ok(());
@@ -2043,16 +2035,16 @@ impl<T: Storage> Raft<T> {
 
                 for (i, e) in m.mut_entries().iter_mut().enumerate() {
                     let mut cc;
-                    if e.get_entry_type() == EntryType::EntryConfChange {
+                    if e.entry_type() == EntryType::EntryConfChange {
                         let mut cc_v1 = ConfChange::default();
-                        if let Err(e) = cc_v1.merge_from_bytes(e.get_data()) {
+                        if let Err(e) = cc_v1.merge_from_bytes(&e.data) {
                             error!(self.logger, "invalid confchange"; "error" => ?e);
                             return Err(Error::ProposalDropped);
                         }
                         cc = cc_v1.into_v2();
-                    } else if e.get_entry_type() == EntryType::EntryConfChangeV2 {
+                    } else if e.entry_type() == EntryType::EntryConfChangeV2 {
                         cc = ConfChangeV2::default();
-                        if let Err(e) = cc.merge_from_bytes(e.get_data()) {
+                        if let Err(e) = cc.merge_from_bytes(&e.data) {
                             error!(self.logger, "invalid confchangev2"; "error" => ?e);
                             return Err(Error::ProposalDropped);
                         }
@@ -2141,7 +2133,7 @@ impl<T: Storage> Raft<T> {
             _ => {}
         }
 
-        match m.get_msg_type() {
+        match m.msg_type() {
             MessageType::MsgAppendResponse => {
                 self.handle_append_response(&m);
             }
@@ -2257,7 +2249,7 @@ impl<T: Storage> Raft<T> {
     // step_candidate is shared by state Candidate and PreCandidate; the difference is
     // whether they respond to MsgRequestVote or MsgRequestPreVote.
     fn step_candidate(&mut self, m: Message) -> Result<()> {
-        match m.get_msg_type() {
+        match m.msg_type() {
             MessageType::MsgPropose => {
                 info!(
                     self.logger,
@@ -2286,14 +2278,14 @@ impl<T: Storage> Raft<T> {
                 // state Candidate, we may get stale MsgPreVoteResp messages in this term from
                 // our pre-candidate state).
                 if (self.state == StateRole::PreCandidate
-                    && m.get_msg_type() != MessageType::MsgRequestPreVoteResponse)
+                    && m.msg_type() != MessageType::MsgRequestPreVoteResponse)
                     || (self.state == StateRole::Candidate
-                        && m.get_msg_type() != MessageType::MsgRequestVoteResponse)
+                        && m.msg_type() != MessageType::MsgRequestVoteResponse)
                 {
                     return Ok(());
                 }
 
-                self.poll(m.from, m.get_msg_type(), !m.reject);
+                self.poll(m.from, m.msg_type(), !m.reject);
                 self.maybe_commit_by_vote(&m);
             }
             MessageType::MsgTimeoutNow => debug!(
@@ -2309,7 +2301,7 @@ impl<T: Storage> Raft<T> {
     }
 
     fn step_follower(&mut self, mut m: Message) -> Result<()> {
-        match m.get_msg_type() {
+        match m.msg_type() {
             MessageType::MsgPropose => {
                 if self.leader_id == INVALID_ID {
                     info!(
@@ -2528,7 +2520,7 @@ impl<T: Storage> Raft<T> {
     }
 
     fn handle_snapshot(&mut self, mut m: Message) {
-        let metadata = m.get_snapshot().get_metadata();
+        let metadata = m.snapshot().metadata();
         let (sindex, sterm) = (metadata.index, metadata.term);
         if self.restore(m.take_snapshot()) {
             info!(
@@ -2563,7 +2555,7 @@ impl<T: Storage> Raft<T> {
     /// Recovers the state machine from a snapshot. It restores the log and the
     /// configuration of state machine.
     pub fn restore(&mut self, snap: Snapshot) -> bool {
-        if snap.get_metadata().index < self.raft_log.committed {
+        if snap.metadata().index < self.raft_log.committed {
             return false;
         }
         if self.state != StateRole::Follower {
@@ -2582,14 +2574,14 @@ impl<T: Storage> Raft<T> {
         // More defense-in-depth: throw away snapshot if recipient is not in the
         // config. This shouldn't ever happen (at the time of writing) but lots of
         // code here and there assumes that r.id is in the progress tracker.
-        let meta = snap.get_metadata();
+        let meta = snap.metadata();
         let (snap_index, snap_term) = (meta.index, meta.term);
-        let cs = meta.get_conf_state();
+        let cs = meta.conf_state();
         if cs
-            .get_voters()
+            .voters
             .iter()
-            .chain(cs.get_learners())
-            .chain(cs.get_voters_outgoing())
+            .chain(cs.learners.iter())
+            .chain(cs.voters_outgoing.iter())
             // `learners_next` doesn't need to be checked. According to the rules, if a peer in
             // `learners_next`, it has to be in `voters_outgoing`.
             .all(|id| *id != self.id)
@@ -2622,8 +2614,8 @@ impl<T: Storage> Raft<T> {
             .raft_log
             .pending_snapshot()
             .unwrap()
-            .get_metadata()
-            .get_conf_state();
+            .metadata()
+            .conf_state();
 
         self.prs.clear();
         let last_index = self.raft_log.last_index();
@@ -2638,8 +2630,8 @@ impl<T: Storage> Raft<T> {
             .raft_log
             .pending_snapshot()
             .unwrap()
-            .get_metadata()
-            .get_conf_state();
+            .metadata()
+            .conf_state();
         if !raft_proto::conf_state_eq(cs, &new_cs) {
             fatal!(self.logger, "invalid restore: {:?} != {:?}", cs, new_cs);
         }
@@ -2717,7 +2709,7 @@ impl<T: Storage> Raft<T> {
                 .r
                 .read_only
                 .recv_ack(self.id, &ctx)
-                .map_or(false, |acks| prs.has_quorum(acks))
+                .is_some_and(|acks| prs.has_quorum(acks))
             {
                 for rs in self.r.read_only.advance(&ctx, &self.r.logger) {
                     if let Some(m) = self.handle_ready_read_index(rs.req, rs.index) {
@@ -2729,7 +2721,7 @@ impl<T: Storage> Raft<T> {
 
         if self
             .lead_transferee
-            .map_or(false, |e| !self.prs.conf().voters.contains(e))
+            .is_some_and(|e| !self.prs.conf().voters.contains(e))
         {
             self.abort_leader_transfer();
         }
@@ -2882,7 +2874,7 @@ impl<T: Storage> Raft<T> {
             warn!(
                 self.r.logger,
                 "try to reduce uncommitted size less than 0, first index of pending ents is {}",
-                ents[0].get_index()
+                ents[0].index
             );
         }
     }

--- a/raft-rs/src/raft_log.rs
+++ b/raft-rs/src/raft_log.rs
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 use std::cmp;
+use std::fmt;
 
 use slog::warn;
 use slog::Logger;
@@ -58,12 +59,13 @@ pub struct RaftLog<T: Storage> {
     pub applied: u64,
 }
 
-impl<T> ToString for RaftLog<T>
+impl<T> fmt::Display for RaftLog<T>
 where
     T: Storage,
 {
-    fn to_string(&self) -> String {
-        format!(
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             "committed={}, persisted={}, applied={}, unstable.offset={}, unstable.entries.len()={}",
             self.committed,
             self.persisted,
@@ -460,7 +462,7 @@ impl<T: Storage> RaftLog<T> {
     /// Returns the current snapshot
     pub fn snapshot(&self, request_index: u64, to: u64) -> Result<Snapshot> {
         if let Some(snap) = self.unstable.snapshot.as_ref() {
-            if snap.get_metadata().index >= request_index {
+            if snap.metadata().index >= request_index {
                 return Ok(snap.clone());
             }
         }
@@ -496,7 +498,7 @@ impl<T: Storage> RaftLog<T> {
 
     /// Attempts to commit the index and term and returns whether it did.
     pub fn maybe_commit(&mut self, max_index: u64, term: u64) -> bool {
-        if max_index > self.committed && self.term(max_index).map_or(false, |t| t == term) {
+        if max_index > self.committed && (self.term(max_index) == Ok(term)) {
             debug!(
                 self.unstable.logger,
                 "committing index {index}",
@@ -526,12 +528,12 @@ impl<T: Storage> RaftLog<T> {
         // because the first_update_index means there are snapshot or some entries whose indexes
         // are greater than or equal to the first_update_index have not been persisted yet.
         let first_update_index = match &self.unstable.snapshot {
-            Some(s) => s.get_metadata().index,
+            Some(s) => s.metadata().index,
             None => self.unstable.offset,
         };
         if index > self.persisted
             && index < first_update_index
-            && self.store.term(index).map_or(false, |t| t == term)
+            && (self.store.term(index) == Ok(term))
         {
             debug!(self.unstable.logger, "persisted index {}", index);
             self.persisted = index;
@@ -628,10 +630,10 @@ impl<T: Storage> RaftLog<T> {
             self.unstable.logger,
             "log [{log}] starts to restore snapshot [index: {snapshot_index}, term: {snapshot_term}]",
             log = self.to_string(),
-            snapshot_index = snapshot.get_metadata().index,
-            snapshot_term = snapshot.get_metadata().term,
+            snapshot_index = snapshot.metadata().index,
+            snapshot_term = snapshot.metadata().term,
         );
-        let index = snapshot.get_metadata().index;
+        let index = snapshot.metadata().index;
         assert!(index >= self.committed, "{} < {}", index, self.committed);
         // If `persisted` is greater than `committed`, reset it to `committed`.
         // It's because only the persisted entries whose index are less than `commited` can be
@@ -883,7 +885,7 @@ mod test {
         assert_eq!(raft_log.committed, unstablesnapi);
         assert_eq!(raft_log.persisted, storagesnapi);
 
-        let tests = vec![
+        let tests = [
             // cannot get term from storage
             (storagesnapi, 0),
             // cannot get term from the gap between storage ents and unstable snapshot
@@ -916,7 +918,7 @@ mod test {
             raft_log.append(&[new_entry(offset + i, i)]);
         }
 
-        let tests = vec![
+        let tests = [
             (offset - 1, 0),
             (offset, 1),
             (offset + num / 2, num / 2),
@@ -1016,7 +1018,7 @@ mod test {
             raft_log.append(new_ents);
             let unstable = raft_log.unstable_entries().to_vec();
             if let Some(e) = unstable.last() {
-                raft_log.stable_entries(e.get_index(), e.get_term());
+                raft_log.stable_entries(e.index(), e.term());
                 raft_log.mut_store().wl().append(&unstable).expect("");
             }
             let is_changed = raft_log.persisted != wpersist;
@@ -1048,7 +1050,7 @@ mod test {
     fn test_unstable_ents() {
         let l = default_logger();
         let previous_ents = vec![new_entry(1, 1), new_entry(2, 2)];
-        let tests = vec![(3, vec![]), (1, previous_ents.clone())];
+        let tests = [(3, vec![]), (1, previous_ents.clone())];
 
         for (i, &(unstable, ref wents)) in tests.iter().enumerate() {
             // append stable entries to storage
@@ -1064,7 +1066,7 @@ mod test {
 
             let ents = raft_log.unstable_entries().to_vec();
             if let Some(e) = ents.last() {
-                raft_log.stable_entries(e.get_index(), e.get_term());
+                raft_log.stable_entries(e.index(), e.term());
             }
             if &ents != wents {
                 panic!("#{}: unstableEnts = {:?}, want {:?}", i, ents, wents);
@@ -1114,7 +1116,7 @@ mod test {
             raft_log.append(&ents);
             let unstable = raft_log.unstable_entries().to_vec();
             if let Some(e) = unstable.last() {
-                raft_log.stable_entries(e.get_index(), e.get_term());
+                raft_log.stable_entries(e.index(), e.term());
                 raft_log.mut_store().wl().append(&unstable).expect("");
             }
             raft_log.maybe_persist(persisted, 1);
@@ -1515,9 +1517,9 @@ mod test {
     #[test]
     fn test_commit_to() {
         let l = default_logger();
-        let previous_ents = vec![new_entry(1, 1), new_entry(2, 2), new_entry(3, 3)];
+        let previous_ents = [new_entry(1, 1), new_entry(2, 2), new_entry(3, 3)];
         let previous_commit = 2u64;
-        let tests = vec![
+        let tests = [
             (3, 3, false),
             (1, 2, false), // never decrease
             (4, 0, true),  // commit out of range -> panic
@@ -1543,7 +1545,7 @@ mod test {
     #[test]
     fn test_compaction() {
         let l = default_logger();
-        let tests = vec![
+        let tests = [
             // out of upper bound
             (1000, vec![1001u64], vec![0usize], true),
             (
@@ -1596,7 +1598,7 @@ mod test {
             raft_log.append(&[new_entry(i + offset, 0)]);
         }
         let first = offset + 1;
-        let tests = vec![
+        let tests = [
             (first - 2, first + 1, false, true),
             (first - 1, first + 1, false, true),
             (first, first, false, false),

--- a/raft-rs/src/raw_node.rs
+++ b/raft-rs/src/raw_node.rs
@@ -374,7 +374,7 @@ impl<T: Storage> RawNode<T> {
     /// If the node enters joint state with `auto_leave` set to true, it's
     /// caller's responsibility to propose an empty conf change again to force
     /// leaving joint state.
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_pass_by_value))]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn propose_conf_change(&mut self, context: Vec<u8>, cc: impl ConfChangeI) -> Result<()> {
         let (data, ty) = if let Some(cc) = cc.as_v1() {
             (cc.write_to_bytes()?, EntryType::EntryConfChange)
@@ -401,10 +401,10 @@ impl<T: Storage> RawNode<T> {
     /// Step advances the state machine using the given message.
     pub fn step(&mut self, m: Message) -> Result<()> {
         // Ignore unexpected local messages receiving over network
-        if is_local_msg(m.get_msg_type()) {
+        if is_local_msg(m.msg_type()) {
             return Err(Error::StepLocalMsg);
         }
-        if self.raft.prs().get(m.from).is_some() || !is_response_msg(m.get_msg_type()) {
+        if self.raft.prs().get(m.from).is_some() || !is_response_msg(m.msg_type()) {
             return self.raft.step(m);
         }
         Err(Error::StepPeerNotFound)
@@ -456,8 +456,8 @@ impl<T: Storage> RawNode<T> {
         // Update raft uncommitted entries size
         raft.reduce_uncommitted_size(&rd.committed_entries);
         if let Some(e) = rd.committed_entries.last() {
-            assert!(self.commit_since_index < e.get_index());
-            self.commit_since_index = e.get_index();
+            assert!(self.commit_since_index < e.index);
+            self.commit_since_index = e.index;
         }
 
         if !raft.msgs.is_empty() {
@@ -516,8 +516,8 @@ impl<T: Storage> RawNode<T> {
 
         if let Some(snapshot) = &raft.raft_log.unstable_snapshot() {
             rd.snapshot = snapshot.clone();
-            assert!(self.commit_since_index <= rd.snapshot.get_metadata().index);
-            self.commit_since_index = rd.snapshot.get_metadata().index;
+            assert!(self.commit_since_index <= rd.snapshot.metadata().index);
+            self.commit_since_index = rd.snapshot.metadata().index;
             // If there is a snapshot, the latter entries can not be persisted
             // so there is no committed entries.
             assert!(
@@ -527,10 +527,7 @@ impl<T: Storage> RawNode<T> {
                 "has snapshot but also has committed entries since {}",
                 self.commit_since_index
             );
-            rd_record.snapshot = Some((
-                rd.snapshot.get_metadata().index,
-                rd.snapshot.get_metadata().term,
-            ));
+            rd_record.snapshot = Some((rd.snapshot.metadata().index, rd.snapshot.metadata().term));
             rd.must_sync = true;
         }
 
@@ -538,7 +535,7 @@ impl<T: Storage> RawNode<T> {
         if let Some(e) = rd.entries.last() {
             // If the last entry exists, the entries must not empty, vice versa.
             rd.must_sync = true;
-            rd_record.last_entry = Some((e.get_index(), e.get_term()));
+            rd_record.last_entry = Some((e.index, e.term));
         }
 
         // Leader can send messages immediately to make replication concurrently.
@@ -571,7 +568,7 @@ impl<T: Storage> RawNode<T> {
             return true;
         }
 
-        if self.snap().map_or(false, |s| !s.is_empty()) {
+        if self.snap().is_some_and(|s| !s.is_empty()) {
             return true;
         }
 

--- a/raft-rs/src/read_only.rs
+++ b/raft-rs/src/read_only.rs
@@ -22,10 +22,11 @@ use crate::eraftpb::Message;
 use crate::{HashMap, HashSet};
 
 /// Determines the relative safety of and consistency of read only requests.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum ReadOnlyOption {
     /// Safe guarantees the linearizability of the read only request by
     /// communicating with the quorum. It is the default and suggested option.
+    #[default]
     Safe,
     /// LeaseBased ensures linearizability of the read only request by
     /// relying on the leader lease. It can be affected by clock drift.
@@ -33,12 +34,6 @@ pub enum ReadOnlyOption {
     /// should (clock can move backward/pause without any bound). ReadIndex is not safe
     /// in that case.
     LeaseBased,
-}
-
-impl Default for ReadOnlyOption {
-    fn default() -> ReadOnlyOption {
-        ReadOnlyOption::Safe
-    }
 }
 
 /// ReadState provides state for read only query.

--- a/raft-rs/src/storage.rs
+++ b/raft-rs/src/storage.rs
@@ -164,7 +164,7 @@ pub trait Storage {
 #[derive(Default)]
 pub struct MemStorageCore {
     raft_state: RaftState,
-    // entries[i] has raft log position i+snapshot.get_metadata().index
+    // entries[i] has raft log position i+snapshot.metadata().index
     entries: Vec<Entry>,
     // Metadata of the last snapshot received.
     snapshot_metadata: SnapshotMetadata,
@@ -511,7 +511,7 @@ impl Storage for MemStorage {
             Err(Error::Store(StorageError::SnapshotTemporarilyUnavailable))
         } else {
             let mut snap = core.snapshot();
-            if snap.get_metadata().index < request_index {
+            if snap.metadata().index < request_index {
                 snap.mut_metadata().index = request_index;
             }
             Ok(snap)
@@ -538,7 +538,7 @@ mod test {
     }
 
     fn size_of<T: PbMessage>(m: &T) -> u32 {
-        m.compute_size()
+        m.compute_size() as u32
     }
 
     fn new_snapshot(index: u64, term: u64, voters: Vec<u64>) -> Snapshot {
@@ -579,7 +579,7 @@ mod test {
             new_entry(5, 5),
             new_entry(6, 6),
         ];
-        let max_u64 = u64::max_value();
+        let max_u64 = u64::MAX;
         let mut tests = vec![
             (
                 2,

--- a/raft-rs/src/tracker/inflights.rs
+++ b/raft-rs/src/tracker/inflights.rs
@@ -85,7 +85,7 @@ impl Inflights {
     /// Returns true if the inflights is full.
     #[inline]
     pub fn full(&self) -> bool {
-        self.count == self.cap || self.incoming_cap.map_or(false, |cap| self.count >= cap)
+        self.count == self.cap || self.incoming_cap.is_some_and(|cap| self.count >= cap)
     }
 
     /// Adds an inflight into inflights

--- a/raft-rs/src/tracker/progress.rs
+++ b/raft-rs/src/tracker/progress.rs
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn test_progress_is_paused() {
-        let tests = vec![
+        let tests = [
             (ProgressState::Probe, false, false),
             (ProgressState::Probe, true, true),
             (ProgressState::Replicate, false, false),
@@ -348,7 +348,7 @@ mod tests {
     #[test]
     fn test_progress_update() {
         let (prev_m, prev_n) = (3u64, 5u64);
-        let tests = vec![
+        let tests = [
             (prev_m - 1, prev_m, prev_n, false),
             (prev_m, prev_m, prev_n, false),
             (prev_m + 1, prev_m + 1, prev_n, true),

--- a/raft-rs/src/tracker/state.rs
+++ b/raft-rs/src/tracker/state.rs
@@ -18,20 +18,15 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 
 /// The state of the progress.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum ProgressState {
     /// Whether it's probing.
+    #[default]
     Probe,
     /// Whether it's replicating.
     Replicate,
     /// Whether it's a snapshot.
     Snapshot,
-}
-
-impl Default for ProgressState {
-    fn default() -> ProgressState {
-        ProgressState::Probe
-    }
 }
 
 impl Display for ProgressState {

--- a/raft-rs/src/util.rs
+++ b/raft-rs/src/util.rs
@@ -5,7 +5,6 @@
 
 use std::fmt;
 use std::fmt::Write;
-use std::u64;
 
 use slog::{OwnedKVList, Record, KV};
 


### PR DESCRIPTION
Major upgrades and fixes for vendored raft-rs and protobuf-build crates:

**Protobuf v2 → v3.7.2**
- Upgrade protobuf and protobuf-codegen from v2 to v3.7.2
- Adapt API changes: compute_size returns u64, ProtobufError → Error
- Add NAME/special_fields to Message trait impls
- Fix compilation warnings (lifetimes, dead code, unused imports)

**protobuf-build code generator fixes**
- Add generate_files() with feature priority (prost-codec takes precedence)
- Fix TokenStream field type comparison by converting to String
- Fix conditional compilation for exports: cfg(not(prost-codec))
- Improve module structure to include wrapper files when both codecs are enabled

**Repository metadata**
- Rename crates: raft → rmqtt-raft-core, raft-proto → rmqtt-raft-proto
- Update repository/homepage URLs to point to RMQTT forks
- Add rmqtt maintainer to authors
- Bump versions: rmqtt-raft-core 0.7.0→0.8.0, protobuf-build 0.15.1→0.16.2
- Update internal dependencies to use renamed crates with correct versions

**Serialization (bincode → postcard)**
- Replace bincode with postcard 1.1 across raft crate and examples
- Update API: serialize → to_stdvec, deserialize → from_bytes
- Update error conversion for postcard::Error

**Hash (fxhash → ahash)**
- Replace fxhash 0.2.1 with ahash 0.8 in raft-rs and harness
- Update HashSet type definitions to use ahash::AHasher

**Code quality fixes**
- Add #![allow(unexpected_cfgs)] to suppress nightly compiler warnings
- Fix hidden lifetime warnings (Cow<'_, T>, Changer<'_>, Status<'_>)
- Remove unused ReadState import, unnecessary mut annotations
- Add #![allow(dead_code)] for generated gRPC types
- Bump box-counter from 0.3 to 0.4