### PR TITLE
feat: upgrade tonic/prost to v0.14 and migrate to tonic-prost-build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-raft"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["rmqtt <rmqttd@126.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -21,14 +21,15 @@ reuseport = ["socket2", "tokio-stream"]
 reuseaddr = ["socket2", "tokio-stream"]
 
 [dependencies]
-tikv-raft = {package = "rmqtt-raft-core", path = "./raft-rs", version = "0.8.0", features = [
+tikv-raft = {package = "rmqtt-raft-core", path = "./raft-rs", version = "0.9.0", features = [
     "prost-codec",
 ], default-features = false }
 tokio = { version = "1", default-features = false, features = ["macros"] }
 socket2 = { version = "0.5", features = ["all"], optional = true }
 tokio-stream = { version = "0.1", features = ["net"], optional = true }
-tonic = "0.9"
-prost = "0.11"
+tonic = "0.14.6"
+tonic-prost = "0.14"
+prost = "0.14.3"
 futures = "0.3"
 
 async-trait = "0.1"
@@ -47,4 +48,4 @@ scopeguard = "1"
 box-counter = { version = "0.4", features = ["count", "rate"] }
 
 [build-dependencies]
-tonic-build = "0.9"
+tonic-prost-build = "0.14"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out = std::env::var("OUT_DIR").unwrap();
     println!("out: {out}");
-    let build_res = tonic_build::configure()
+    let build_res = tonic_prost_build::configure()
         .out_dir(out)
-        .compile(&["raft_service.proto"], &["proto/"]);
+        .compile_protos(&["raft_service.proto"], &["proto/"]);
     println!("compile proto result! {build_res:?}");
     build_res.unwrap();
     Ok(())

--- a/raft-rs/Cargo.toml
+++ b/raft-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-raft-core"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["The TiKV Project Developers", "rmqtt <rmqttd@126.com>"]
 license = "Apache-2.0"
 keywords = ["raft", "distributed-systems", "ha"]
@@ -30,7 +30,7 @@ fail = { version = "0.4", optional = true }
 getset = "0.1.1"
 protobuf = "3.7.2"
 thiserror = "1.0"
-raft-proto = {package = "rmqtt-raft-proto", path = "./proto", version = "0.8.0", default-features = false }
+raft-proto = {package = "rmqtt-raft-proto", path = "./proto", version = "0.9.0", default-features = false }
 rand = "0.8"
 slog = "2.2"
 slog-envlogger = { version = "2.1.0", optional = true }

--- a/raft-rs/proto/Cargo.toml
+++ b/raft-rs/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-raft-proto"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["The TiKV Project Developers", "rmqtt <rmqttd@126.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -17,10 +17,10 @@ protobuf-codec = ["protobuf-build/protobuf-codec", "bytes", "protobuf/bytes"]
 prost-codec = ["protobuf-build/prost-codec", "prost", "lazy_static"]
 
 [build-dependencies]
-protobuf-build = {package = "rmqtt-protobuf-build", path = "./protobuf-build", version = "0.16.2", default-features = false }
+protobuf-build = {package = "rmqtt-protobuf-build", path = "./protobuf-build", version = "0.17.0", default-features = false }
 
 [dependencies]
 bytes = { version = "1", optional = true }
 lazy_static = { version = "1", optional = true }
-prost = { version = "0.11", optional = true }
+prost = { version = "0.14.3", optional = true }
 protobuf = "3.7.2"

--- a/raft-rs/proto/protobuf-build/Cargo.toml
+++ b/raft-rs/proto/protobuf-build/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rmqtt-protobuf-build"
-version = "0.16.2"
+version = "0.17.0"
 authors = ["Nick Cameron <nrc@ncameron.org>", "rmqtt <rmqttd@126.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rmqtt/rmqtt-raft/tree/main/raft-rs/proto/protobuf-build"
 homepage = "https://github.com/rmqtt/rmqtt-raft/tree/main/raft-rs/proto/protobuf-build"
@@ -20,8 +20,8 @@ proc-macro2 = { version = "1", optional = true }
 protobuf = { version = "3.7.2", optional = true }
 protobuf-codegen = { version = "3.7.2", optional = true }
 protobuf-parse = { version = "3.7.2", optional = true }
-grpcio-compiler = {package = "rmqtt-grpcio-compiler", path = "./compiler", version = "0.14", default-features = false, optional = true }
-prost-build = { version = "0.11", optional = true }
+grpcio-compiler = {package = "rmqtt-grpcio-compiler", path = "./compiler", version = "0.15.0", default-features = false, optional = true }
+prost-build = { version = "0.14.3", optional = true }
 regex = { version = "1.3" }
 syn = { version = "1.0", features = ["full"], optional = true }
 quote = { version = "1.0", optional = true }

--- a/raft-rs/proto/protobuf-build/compiler/Cargo.toml
+++ b/raft-rs/proto/protobuf-build/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-grpcio-compiler"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2018"
 authors = ["The TiKV Project Developers", "rmqtt <rmqttd@126.com>"]
 license = "Apache-2.0"
@@ -17,9 +17,9 @@ prost-codec = ["prost-build", "prost-types", "prost", "derive-new", "tempfile"]
 
 [dependencies]
 protobuf = { version = "3.7.2", optional = true }
-prost = { version = "0.11", optional = true }
-prost-build = { version = "0.11", optional = true }
-prost-types = { version = "0.11", optional = true }
+prost = { version = "0.14.3", optional = true }
+prost-build = { version = "0.14.3", optional = true }
+prost-types = { version = "0.14.3", optional = true }
 derive-new = { version = "0.5", optional = true }
 tempfile = { version = "3.0", optional = true }
 

--- a/raft-rs/proto/protobuf-build/src/wrapper.rs
+++ b/raft-rs/proto/protobuf-build/src/wrapper.rs
@@ -398,9 +398,9 @@ impl FieldKind {
                 result.get = Some(match &**fk {
                     FieldKind::Enumeration(t) => format!(
                         "match self.{} {{
-                            Some(v) => match {}::from_i32(v) {{\
-                                Some(e) => e,
-                                None => panic!(\"Unknown enum variant: {{}}\", v),
+                            Some(v) => match <{} as ::std::convert::TryFrom<i32>>::try_from(v) {{\
+                                Ok(e) => e,
+                                Err(_) => panic!(\"Unknown enum variant: {{}}\", v),
                             }},
                             None => {}::default(),
                         }}",
@@ -500,9 +500,9 @@ impl FieldKind {
                 result.enum_set = true;
                 result.prost_has_unprefixed = true;
                 result.get = Some(format!(
-                    "match {}::from_i32(self.{}) {{\
-                        Some(e) => e,
-                        None => panic!(\"Unknown enum variant: {{}}\", self.{1}),
+                    "match <{} as ::std::convert::TryFrom<i32>>::try_from(self.{}) {{\
+                        Ok(e) => e,
+                        Err(_) => panic!(\"Unknown enum variant: {{}}\", self.{1}),
                     }}",
                     type_in_expr_context(enum_type),
                     result.name,

--- a/src/raft_server.rs
+++ b/src/raft_server.rs
@@ -62,7 +62,6 @@ impl RaftServer {
         let svc = RaftServiceServer::new(self)
             .max_decoding_message_size(_cfg.grpc_message_size)
             .max_encoding_message_size(_cfg.grpc_message_size);
-        let server = Server::builder().add_service(svc);
 
         #[cfg(any(feature = "reuseport", feature = "reuseaddr"))]
         #[cfg(all(feature = "socket2", feature = "tokio-stream"))]
@@ -73,10 +72,10 @@ impl RaftServer {
                 _cfg.reuseport
             );
             let listener = raft_service::bind(laddr, 1024, _cfg.reuseaddr, _cfg.reuseport)?;
-            server.serve_with_incoming(listener).await?;
+            Server::builder().serve_with_incoming(svc, listener).await?;
         }
         #[cfg(not(any(feature = "reuseport", feature = "reuseaddr")))]
-        server.serve(laddr).await?;
+        Server::builder().serve(laddr, svc).await?;
 
         info!("server has quit");
         Ok(())

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -100,7 +100,7 @@ impl LogStore for MemStorage {
     #[inline]
     fn set_hard_state(&mut self, hard_state: &HardState) -> Result<()> {
         let mut store = self.core.wl();
-        store.set_hardstate(hard_state.clone());
+        store.set_hardstate(*hard_state);
         Ok(())
     }
 
@@ -117,7 +117,7 @@ impl LogStore for MemStorage {
     #[inline]
     fn set_hard_state_comit(&mut self, comit: u64) -> Result<()> {
         let mut store = self.core.wl();
-        let mut hard_state = store.hard_state().clone();
+        let mut hard_state = *store.hard_state();
         hard_state.set_commit(comit);
         store.set_hardstate(hard_state);
         Ok(())


### PR DESCRIPTION
**Breaking Changes: gRPC stack upgrade**
- Upgrade tonic from 0.9 to 0.14.6
- Upgrade prost from 0.11 to 0.14.3
- Replace tonic-build with tonic-prost-build 0.14
- Update build.rs to use new API (compile_protos instead of compile)

**Version Bumps**
- rmqtt-raft: 0.7.1 → 0.8.0
- rmqtt-raft-core: 0.8.0 → 0.9.0
- rmqtt-raft-proto: 0.8.0 → 0.9.0
- rmqtt-protobuf-build: 0.16.2 → 0.17.0
- rmqtt-grpcio-compiler: 0.14.1 → 0.15.0

**API Changes**
- Update tonic server builder API: `server.add_service(svc)` → `Server::builder().serve_with_incoming(svc, listener)`
- Fix HardState clone to dereference (removes unnecessary clone)
- Update protobuf-build enum code generation to use TryFrom<i32> instead of from_i32
- Bump edition from 2018 to 2021 for protobuf-build

**Dependencies**
- prost 0.11 → 0.14.3 across all sub-crates
- prost-build 0.11 → 0.14.3
- grpcio-compiler 0.14 → 0.15 (with prost 0.14.3)

This upgrade enables modern gRPC features and aligns with the latest tonic/prost ecosystem.